### PR TITLE
fix: clarify converter work time and mobile actions

### DIFF
--- a/apps/web/src/pages/Converter.css
+++ b/apps/web/src/pages/Converter.css
@@ -1,0 +1,86 @@
+.converter-live-result small{
+  line-height:1.35;
+}
+
+.converter-result{
+  display:grid;
+  grid-template-columns:repeat(2,minmax(120px,auto));
+  gap:22px;
+  min-width:270px;
+}
+
+.converter-result>div{
+  display:flex;
+  flex-direction:column;
+  gap:3px;
+}
+
+.converter-result small{
+  line-height:1.35;
+  white-space:nowrap;
+}
+
+.converter-result strong{
+  white-space:nowrap;
+}
+
+@media(max-width:560px){
+  .converter-card{
+    grid-template-columns:40px minmax(0,1fr) 40px;
+    grid-template-areas:
+      "avatar main delete"
+      "result result result";
+    align-items:start;
+    column-gap:11px;
+    row-gap:12px;
+    padding:13px 14px 14px;
+  }
+
+  .converter-card>.item-avatar{
+    grid-area:avatar;
+  }
+
+  .converter-card>.item-main{
+    grid-area:main;
+    min-width:0;
+    padding-top:2px;
+  }
+
+  .converter-card>.item-main b{
+    overflow-wrap:anywhere;
+    line-height:1.45;
+  }
+
+  .converter-card>.converter-result{
+    grid-area:result;
+    min-width:0;
+    width:100%;
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    gap:12px;
+    text-align:left;
+    border-top:1px solid var(--line);
+    padding-top:11px;
+  }
+
+  .converter-card>.converter-result small,
+  .converter-card>.converter-result strong{
+    white-space:normal;
+  }
+
+  .converter-card>.icon-button{
+    grid-area:delete;
+    display:grid!important;
+    justify-self:end;
+    width:40px;
+    height:40px;
+    margin-top:-2px;
+    touch-action:manipulation;
+  }
+}
+
+@media(max-width:380px){
+  .converter-card>.converter-result{
+    grid-template-columns:1fr;
+    gap:9px;
+  }
+}

--- a/apps/web/src/pages/Converter.tsx
+++ b/apps/web/src/pages/Converter.tsx
@@ -5,6 +5,12 @@ import { useSearchParams } from 'react-router-dom'
 import { loadProfile } from '../lib/profile'
 import { keys, loadJSON, saveJSON } from '../lib/storage'
 import type { WishItem } from '../types'
+import './Converter.css'
+
+function formatWorkDays(workSeconds: number, paidSecondsPerDay: number) {
+  if (!Number.isFinite(workSeconds) || !Number.isFinite(paidSecondsPerDay) || paidSecondsPerDay <= 0) return '∞'
+  return (workSeconds / paidSecondsPerDay).toFixed(2)
+}
 
 export function Converter() {
   const [search] = useSearchParams()
@@ -14,8 +20,13 @@ export function Converter() {
   const [price, setPrice] = useState(search.get('price') || '')
   const add = (e: FormEvent) => { e.preventDefault(); const n=Number(price); if(!name.trim() || !Number.isFinite(n) || n<0) return; const next=[{id:crypto.randomUUID(),name:name.trim(),price:n,createdAt:new Date().toISOString()},...items]; setItems(next); saveJSON(keys.wishes,next); setName(''); setPrice('') }
   const remove=(id:string)=>{const next=items.filter(i=>i.id!==id);setItems(next);saveJSON(keys.wishes,next)}
+  const previewPrice = Number(price)
+  const previewWorkSeconds = price && Number.isFinite(previewPrice) && previewPrice >= 0
+    ? priceToWorkSeconds(previewPrice, rates.second)
+    : null
+
   return <section className="page"><header className="page-header"><div><p className="eyebrow">TIME CONVERTER</p><h1>这个东西，值你工作多久？</h1><p>把价格换算成真实的工作时间，而不是一个抽象的数字。</p></div></header>
-    <form className="input-card" onSubmit={add}><label><span>想买什么</span><input value={name} onChange={e=>setName(e.target.value)} placeholder="例如：AirPods Pro" /></label><label><span>价格</span><div className="money-input"><i>¥</i><input value={price} onChange={e=>setPrice(e.target.value)} inputMode="decimal" placeholder="1899" /></div></label>{price && Number(price)>=0 && <div className="live-result"><small>需要工作</small><strong>{formatDuration(priceToWorkSeconds(Number(price), rates.second))}</strong><span>≈ {(priceToWorkSeconds(Number(price),rates.second)/rates.paidSecondsPerDay).toFixed(2)} 个工作日</span></div>}<button className="primary-button" type="submit"><Plus size={17}/> 保存换算</button></form>
-    <div className="list-section"><div className="section-title"><h2>我的换算</h2><span>{items.length} 项</span></div>{items.length===0 ? <div className="empty">还没有记录。先把一个想买的东西换成工作时间吧。</div> : <div className="item-list">{items.map(i=><article className="list-card" key={i.id}><div className="item-avatar">{i.name.slice(0,1).toUpperCase()}</div><div className="item-main"><b>{i.name}</b><span>¥{i.price.toLocaleString()}</span></div><div className="item-result"><small>需要工作</small><strong>{formatDuration(priceToWorkSeconds(i.price,rates.second))}</strong></div><button className="icon-button" onClick={()=>remove(i.id)} aria-label="删除"><Trash2 size={17}/></button></article>)}</div>}</div>
+    <form className="input-card" onSubmit={add}><label><span>想买什么</span><input value={name} onChange={e=>setName(e.target.value)} placeholder="例如：AirPods Pro" /></label><label><span>价格</span><div className="money-input"><i>¥</i><input value={price} onChange={e=>setPrice(e.target.value)} inputMode="decimal" placeholder="1899" /></div></label>{previewWorkSeconds !== null && <div className="live-result converter-live-result"><small>连续纯工时（24小时制）</small><strong>{formatDuration(previewWorkSeconds)}</strong><span>按你的工作日程 ≈ {formatWorkDays(previewWorkSeconds, rates.paidSecondsPerDay)} 个工作日</span></div>}<button className="primary-button" type="submit"><Plus size={17}/> 保存换算</button></form>
+    <div className="list-section"><div className="section-title"><h2>我的换算</h2><span>{items.length} 项</span></div>{items.length===0 ? <div className="empty">还没有记录。先把一个想买的东西换成工作时间吧。</div> : <div className="item-list">{items.map(i=>{const workSeconds=priceToWorkSeconds(i.price,rates.second); return <article className="list-card converter-card" key={i.id}><div className="item-avatar">{i.name.slice(0,1).toUpperCase()}</div><div className="item-main"><b>{i.name}</b><span>¥{i.price.toLocaleString()}</span></div><div className="item-result converter-result"><div><small>连续纯工时（24小时制）</small><strong>{formatDuration(workSeconds)}</strong></div><div><small>按你的工作日程</small><strong>≈ {formatWorkDays(workSeconds, rates.paidSecondsPerDay)} 个工作日</strong></div></div><button className="icon-button" type="button" onClick={()=>remove(i.id)} aria-label={`删除 ${i.name}`} title="删除"><Trash2 size={17}/></button></article>})}</div>}</div>
   </section>
 }


### PR DESCRIPTION
Fixes the two converter acceptance issues:

- distinguish continuous pure work time (24-hour basis) from workdays based on the user's configured daily paid schedule
- show both values in saved conversion cards, matching the preview calculation
- restore the delete action on <=560px layouts (it was explicitly hidden by the global mobile CSS)
- use a dedicated responsive converter-card layout so long names/results cannot push the delete button off-screen
- increase the mobile delete target to 40x40 and keep it visible at 320-560px widths

No salary-rate calculation logic is changed.