### PR TITLE
style: left align converter result details

### DIFF
--- a/apps/web/src/pages/Converter.css
+++ b/apps/web/src/pages/Converter.css
@@ -4,24 +4,30 @@
 
 .converter-result{
   display:grid;
-  grid-template-columns:repeat(2,minmax(120px,auto));
-  gap:22px;
-  min-width:270px;
+  grid-template-columns:repeat(2,minmax(128px,auto));
+  gap:26px;
+  min-width:290px;
+  justify-self:end;
+  align-items:start;
+  text-align:left;
 }
 
 .converter-result>div{
   display:flex;
   flex-direction:column;
-  gap:3px;
+  align-items:flex-start;
+  gap:4px;
 }
 
 .converter-result small{
   line-height:1.35;
   white-space:nowrap;
+  color:var(--muted);
 }
 
 .converter-result strong{
   white-space:nowrap;
+  line-height:1.35;
 }
 
 @media(max-width:560px){
@@ -53,6 +59,7 @@
 
   .converter-card>.converter-result{
     grid-area:result;
+    justify-self:stretch;
     min-width:0;
     width:100%;
     grid-template-columns:repeat(2,minmax(0,1fr));


### PR DESCRIPTION
Polishes the saved converter card result area by keeping the result block on the right while left-aligning its internal text. Also slightly improves spacing and label hierarchy without changing calculations or mobile behavior.