### PR TITLE
feat: add Android APK build and iOS PWA install support

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -1,0 +1,66 @@
+name: Build Android APK
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'apps/web/**'
+      - 'packages/core/**'
+      - '.github/workflows/build-android-apk.yml'
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  android-apk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Install web dependencies
+        run: npm ci
+      - name: Build web bundle
+        env:
+          VITE_API_BASE_URL: https://salary-flow-api.vercel.app
+        run: |
+          npm run build -w @salary-flow/core
+          npm run build -w @salary-flow/web
+      - name: Install pinned Capacitor toolchain
+        run: npm install --no-save --package-lock=false -w @salary-flow/web @capacitor/core@8.5.0 @capacitor/android@8.5.0 @capacitor/cli@8.5.0
+      - name: Generate Android project
+        working-directory: apps/web
+        run: |
+          npx cap add android
+          npx cap sync android
+      - name: Build installable APK
+        working-directory: apps/web/android
+        run: |
+          chmod +x gradlew
+          ./gradlew assembleDebug --no-daemon
+      - name: Prepare APK artifact
+        run: |
+          mkdir -p artifacts
+          cp apps/web/android/app/build/outputs/apk/debug/app-debug.apk artifacts/money-dance-android.apk
+          sha256sum artifacts/money-dance-android.apk > artifacts/money-dance-android.apk.sha256
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: money-dance-android-apk
+          path: |
+            artifacts/money-dance-android.apk
+            artifacts/money-dance-android.apk.sha256
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -40,7 +40,7 @@ jobs:
           npm run build -w @salary-flow/core
           npm run build -w @salary-flow/web
       - name: Install pinned Capacitor toolchain
-        run: npm install --no-save --package-lock=false -w @salary-flow/web @capacitor/core@8.5.0 @capacitor/android@8.5.0 @capacitor/cli@8.5.0
+        run: npm install --no-save --package-lock=false @capacitor/core@8.5.0 @capacitor/android@8.5.0 @capacitor/cli@8.5.0
       - name: Generate Android project
         working-directory: apps/web
         run: |

--- a/apps/web/capacitor.config.json
+++ b/apps/web/capacitor.config.json
@@ -1,0 +1,5 @@
+{
+  "appId": "com.cshouuu.moneydance",
+  "appName": "Money Dance",
+  "webDir": "dist"
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,10 +2,16 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#f5f2ea" />
-    <meta name="description" content="SalaryFlow 薪流：把工资、工作时间和消费连接起来。" />
-    <title>SalaryFlow · 薪流</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#1e281f" />
+    <meta name="description" content="Money Dance 薪流：把工资、工作时间和消费连接起来。" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Money Dance" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="icon" href="/money-dance-icon.svg" type="image/svg+xml" />
+    <title>Money Dance · 薪流</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Money Dance · 薪流",
+  "short_name": "Money Dance",
+  "description": "把工资、工作时间、消费和生活成本连接起来。",
+  "lang": "zh-CN",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "background_color": "#f5f2ea",
+  "theme_color": "#1e281f",
+  "icons": [
+    {
+      "src": "/money-dance-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/apps/web/public/money-dance-icon.svg
+++ b/apps/web/public/money-dance-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Money Dance">
+  <rect width="512" height="512" rx="116" fill="#1e281f"/>
+  <circle cx="256" cy="256" r="158" fill="#dfe8b6"/>
+  <path d="M160 292c22-70 62-112 96-112 33 0 54 26 74 66 12 23 24 35 42 35 15 0 29-9 40-28-5 68-48 111-104 111-45 0-70-24-92-66-15-29-27-42-43-42-16 0-31 12-45 36 8-38 19-69 32-92z" fill="#1e281f"/>
+  <circle cx="298" cy="222" r="12" fill="#dfe8b6"/>
+  <path d="M146 339c40 25 83 37 130 37 39 0 77-8 114-25" fill="none" stroke="#1e281f" stroke-width="18" stroke-linecap="round"/>
+</svg>

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'money-dance-v1'
+const APP_SHELL = ['/', '/index.html', '/manifest.webmanifest', '/money-dance-icon.svg']
+
+self.addEventListener('install', event => {
+  event.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(APP_SHELL)))
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))))
+  )
+  self.clients.claim()
+})
+
+self.addEventListener('fetch', event => {
+  const request = event.request
+  if (request.method !== 'GET') return
+  const url = new URL(request.url)
+  if (url.origin !== self.location.origin) return
+
+  event.respondWith(
+    fetch(request)
+      .then(response => {
+        if (response.ok) {
+          const copy = response.clone()
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy))
+        }
+        return response
+      })
+      .catch(() => caches.match(request).then(cached => cached || caches.match('/')))
+  )
+})

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,5 +2,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './styles.css'
+import './mobile.css'
 
 createRoot(document.getElementById('root')!).render(<StrictMode><App/></StrictMode>)
+
+const isNativeShell = 'Capacitor' in window
+if ('serviceWorker' in navigator && !isNativeShell && import.meta.env.PROD) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => undefined)
+  })
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,7 +7,8 @@ import './mobile.css'
 createRoot(document.getElementById('root')!).render(<StrictMode><App/></StrictMode>)
 
 const isNativeShell = 'Capacitor' in window
-if ('serviceWorker' in navigator && !isNativeShell && import.meta.env.PROD) {
+const isLocalDev = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+if ('serviceWorker' in navigator && !isNativeShell && !isLocalDev) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js').catch(() => undefined)
   })

--- a/apps/web/src/mobile.css
+++ b/apps/web/src/mobile.css
@@ -1,0 +1,4 @@
+html,body,#root{min-height:100%}
+body{padding-top:env(safe-area-inset-top);padding-left:env(safe-area-inset-left);padding-right:env(safe-area-inset-right)}
+@media(max-width:900px){.mobile-nav{left:calc(12px + env(safe-area-inset-left));right:calc(12px + env(safe-area-inset-right));bottom:calc(12px + env(safe-area-inset-bottom))}.page{padding-bottom:calc(100px + env(safe-area-inset-bottom))}}
+@media(display-mode:standalone){body{overscroll-behavior-y:none;-webkit-user-select:none;user-select:none}input,textarea,select,[contenteditable=true]{-webkit-user-select:text;user-select:text}}

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -1,0 +1,48 @@
+# Money Dance Mobile
+
+Money Dance keeps the existing React/Vite application as the single UI/codebase and uses Capacitor as the native shell.
+
+## App identity
+
+- App name: `Money Dance`
+- App ID / Android application ID: `com.cshouuu.moneydance`
+- Web bundle: `apps/web/dist`
+- Capacitor: `8.5.0` (pinned by CI)
+
+## Android APK
+
+The repository contains `.github/workflows/build-android-apk.yml`.
+
+It builds the current web application, creates a Capacitor Android project on the CI runner, synchronizes the web assets, builds an installable APK, and uploads:
+
+- `money-dance-android.apk`
+- `money-dance-android.apk.sha256`
+
+The first CI package uses Android debug signing so it can be installed directly for device acceptance testing. Do not treat the debug key as the long-term release identity. Before distributing updateable release builds broadly, configure one persistent release keystore through GitHub Actions secrets and switch the workflow to `assembleRelease`.
+
+### Local Android development
+
+Requirements: Node.js 22+, JDK 21, Android SDK / Android Studio.
+
+```bash
+npm ci
+npm run build -w @salary-flow/core
+npm run build -w @salary-flow/web
+npm install --no-save --package-lock=false -w @salary-flow/web @capacitor/core@8.5.0 @capacitor/android@8.5.0 @capacitor/cli@8.5.0
+cd apps/web
+npx cap add android
+npx cap sync android
+npx cap open android
+```
+
+The generated `android/` directory is intentionally reproducible from source and does not need to be committed for CI APK builds.
+
+## iOS without a paid Apple Developer account
+
+The web app is now installable as a PWA from Safari through **Add to Home Screen**. It includes standalone display metadata, viewport safe-area support, an app manifest, icon, and an offline service worker.
+
+A Capacitor iOS project can also be generated later on macOS with Xcode using the same `capacitor.config.json`. A free Apple ID can be used for limited Personal Team device testing; App Store / TestFlight distribution is intentionally out of scope until a paid Apple Developer membership exists.
+
+## Data behavior
+
+The mobile shell currently preserves the existing local-first model. Salary profile, wishes, slacking sessions, assets, and ledger records remain device-local. Installing the native APK does not automatically import localStorage data from the Cloudflare-hosted web version because the native WebView has its own storage container.


### PR DESCRIPTION
Adds the first mobile delivery path without rewriting the React/Vite app.

- add Capacitor 8.5.0 config with app id `com.cshouuu.moneydance`
- add Android APK workflow that builds a real installable APK artifact from the existing web bundle
- keep Capacitor CLI/platform packages pinned and CI-only so the web dependency lockfile stays lean
- add PWA manifest, app icon, service worker and iOS standalone metadata
- add safe-area styles for iPhone/Android gesture areas
- document Android local development, APK signing caveat, iOS PWA behavior and future Xcode path

The first Android package is debug-signed for direct device acceptance testing. A persistent encrypted release keystore will be added after the APK flow is verified, so no signing private key is committed to the repository.