### PR TITLE
fix: refine mobile glass dock and converter inset

### DIFF
--- a/apps/web/src/components/Shell.css
+++ b/apps/web/src/components/Shell.css
@@ -10,39 +10,35 @@
 
 @media(max-width:900px){
   .mobile-nav-layer{display:block;position:fixed;inset:0;z-index:45;pointer-events:none}
-  .mobile-nav-backdrop{position:absolute;inset:0;border:0;background:rgba(24,30,24,.18);backdrop-filter:blur(0);opacity:0;pointer-events:none;transition:opacity .28s ease,backdrop-filter .35s ease}
-  .mobile-nav-layer.open .mobile-nav-backdrop{opacity:1;pointer-events:auto;backdrop-filter:blur(3px)}
+  .mobile-nav-backdrop{position:absolute;inset:0;border:0;background:rgba(23,29,23,.06);backdrop-filter:blur(0);opacity:0;pointer-events:none;transition:opacity .28s ease,backdrop-filter .34s ease}
+  .mobile-nav-layer.open .mobile-nav-backdrop{opacity:1;pointer-events:auto;backdrop-filter:blur(2px)}
 
-  .mobile-dock{position:absolute;left:12px;right:12px;bottom:calc(10px + env(safe-area-inset-bottom,0px));pointer-events:auto;background:rgba(30,40,31,.96);border:1px solid rgba(255,255,255,.06);border-radius:20px;padding:9px;box-shadow:0 18px 48px rgba(25,30,24,.26);backdrop-filter:blur(20px);transform:translateZ(0);transition:box-shadow .35s ease,border-radius .35s ease}
-  .mobile-nav-layer.open .mobile-dock{box-shadow:0 24px 60px rgba(25,30,24,.34);border-radius:24px}
+  .mobile-dock{position:absolute;left:14px;right:14px;bottom:calc(11px + env(safe-area-inset-bottom,0px));pointer-events:auto;background:linear-gradient(180deg,rgba(255,255,255,.76),rgba(245,244,237,.68));border:1px solid rgba(255,255,255,.86);border-radius:22px;padding:7px 8px 8px;box-shadow:0 12px 34px rgba(41,49,39,.14),inset 0 1px 0 rgba(255,255,255,.78);-webkit-backdrop-filter:blur(24px) saturate(145%);backdrop-filter:blur(24px) saturate(145%);transform:translateZ(0);transition:box-shadow .36s ease,transform .36s cubic-bezier(.22,.8,.24,1)}
+  .mobile-nav-layer.open .mobile-dock{box-shadow:0 18px 44px rgba(41,49,39,.18),inset 0 1px 0 rgba(255,255,255,.84);transform:translateY(-1px)}
 
-  .mobile-dock-handle{position:absolute;left:50%;top:-17px;transform:translateX(-50%);width:52px;height:24px;border:1px solid rgba(255,255,255,.08);border-radius:999px;background:rgba(30,40,31,.72);backdrop-filter:blur(14px);color:rgba(242,240,228,.66);display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 5px 15px rgba(22,28,22,.12);transition:background .25s ease,color .25s ease,transform .35s cubic-bezier(.22,.8,.24,1)}
-  .mobile-dock-handle span{position:absolute;width:20px;height:2px;border-radius:99px;background:rgba(242,240,228,.2);top:4px}
-  .mobile-dock-handle svg{margin-top:4px;transition:transform .4s cubic-bezier(.22,.8,.24,1)}
-  .mobile-nav-layer.open .mobile-dock-handle{color:rgba(242,240,228,.9);background:rgba(30,40,31,.92)}
+  .mobile-dock-handle{position:absolute;left:50%;top:-10px;transform:translateX(-50%);width:32px;height:16px;border:1px solid rgba(255,255,255,.84);border-bottom:0;border-radius:12px 12px 0 0;background:rgba(250,249,244,.7);-webkit-backdrop-filter:blur(20px);backdrop-filter:blur(20px);color:rgba(61,73,59,.58);display:grid;place-items:center;cursor:pointer;padding:0;box-shadow:0 -3px 10px rgba(45,53,43,.05);transition:color .24s ease,background .24s ease}
+  .mobile-dock-handle svg{transition:transform .38s cubic-bezier(.22,.8,.24,1)}
+  .mobile-nav-layer.open .mobile-dock-handle{color:rgba(45,58,44,.86);background:rgba(250,249,244,.86)}
   .mobile-nav-layer.open .mobile-dock-handle svg{transform:rotate(180deg)}
 
-  .mobile-dock-row{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:5px}
-  .mobile-dock-item,.mobile-drawer-item{text-decoration:none;color:#a5afa3;display:flex;align-items:center;justify-content:center;border-radius:13px;transition:background .25s ease,color .25s ease,transform .18s ease}
-  .mobile-dock-item{height:52px;flex-direction:column;gap:4px;font-size:9px;font-weight:600}
-  .mobile-dock-item.active{background:#3c493b;color:#f4f1e5}
+  .mobile-dock-row{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:4px}
+  .mobile-dock-item,.mobile-drawer-item{text-decoration:none;color:#768074;display:flex;align-items:center;justify-content:center;border-radius:14px;transition:background .24s ease,color .24s ease,transform .18s ease,box-shadow .24s ease}
+  .mobile-dock-item{height:50px;flex-direction:column;gap:3px;font-size:9px;font-weight:650}
+  .mobile-dock-item.active{background:rgba(48,64,47,.9);color:#f6f3e8;box-shadow:0 5px 15px rgba(44,57,43,.16)}
   .mobile-dock-item:active,.mobile-drawer-item:active{transform:scale(.96)}
 
-  .mobile-drawer{max-height:0;opacity:0;overflow:hidden;transform:translateY(18px);transition:max-height .44s cubic-bezier(.22,.8,.24,1),opacity .25s ease,transform .44s cubic-bezier(.22,.8,.24,1),padding .44s cubic-bezier(.22,.8,.24,1)}
-  .mobile-nav-layer.open .mobile-drawer{max-height:270px;opacity:1;transform:translateY(0);padding:13px 4px 11px}
-  .mobile-drawer-title{display:flex;align-items:center;justify-content:space-between;padding:0 5px 11px;color:#f2f0e4}
-  .mobile-drawer-title b{font-size:12px}
-  .mobile-drawer-title span{font-size:9px;color:#8e998d}
-  .mobile-drawer-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:7px}
-  .mobile-drawer-item{min-height:62px;flex-direction:column;gap:6px;background:rgba(255,255,255,.035);font-size:10px;font-weight:600}
-  .mobile-drawer-item.active{background:#465745;color:#f4f1e5;box-shadow:inset 0 0 0 1px rgba(223,232,182,.08)}
+  .mobile-drawer{max-height:0;opacity:0;overflow:hidden;transform:translateY(18px);padding:0 2px;transition:max-height .42s cubic-bezier(.22,.8,.24,1),opacity .24s ease,transform .42s cubic-bezier(.22,.8,.24,1),padding .42s cubic-bezier(.22,.8,.24,1)}
+  .mobile-nav-layer.open .mobile-drawer{max-height:82px;opacity:1;transform:translateY(0);padding:7px 2px 8px}
+  .mobile-drawer-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:6px}
+  .mobile-drawer-item{min-height:58px;flex-direction:column;gap:5px;background:rgba(255,255,255,.42);border:1px solid rgba(255,255,255,.58);font-size:10px;font-weight:650;color:#687267;box-shadow:inset 0 1px 0 rgba(255,255,255,.5)}
+  .mobile-drawer-item.active{background:rgba(223,232,182,.66);color:#41503f;box-shadow:inset 0 0 0 1px rgba(94,116,90,.08)}
 }
 
 @media(max-width:390px){
-  .mobile-dock{left:9px;right:9px;padding:8px}
-  .mobile-dock-item{height:49px}
+  .mobile-dock{left:10px;right:10px;padding:7px}
+  .mobile-dock-item{height:48px}
   .mobile-drawer-grid{gap:5px}
-  .mobile-drawer-item{min-height:58px}
+  .mobile-drawer-item{min-height:56px}
 }
 
 @media(prefers-reduced-motion:reduce){

--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -14,6 +14,7 @@ const items = [
 ] as const
 
 const compactItems = items.filter(([, , , compact]) => compact)
+const drawerItems = items.filter(([, , , compact]) => !compact)
 
 export function Shell() {
   const location = useLocation()
@@ -31,19 +32,19 @@ export function Shell() {
     const endY = event.changedTouches[0]?.clientY ?? touchStartY.current
     const delta = endY - touchStartY.current
     touchStartY.current = null
-    if (delta < -28) setMobileOpen(true)
-    if (delta > 28) setMobileOpen(false)
+    if (delta < -24) setMobileOpen(true)
+    if (delta > 24) setMobileOpen(false)
   }
 
-  const renderItem = ([to, Icon, label]: (typeof items)[number], expanded = false) => (
+  const renderItem = ([to, Icon, label]: (typeof items)[number], drawer = false) => (
     <NavLink
-      key={`${expanded ? 'expanded' : 'compact'}-${to}`}
+      key={`${drawer ? 'drawer' : 'compact'}-${to}`}
       to={to}
       end={to === '/'}
       onClick={() => setMobileOpen(false)}
-      className={({ isActive }) => `${expanded ? 'mobile-drawer-item' : 'mobile-dock-item'}${isActive ? ' active' : ''}`}
+      className={({ isActive }) => `${drawer ? 'mobile-drawer-item' : 'mobile-dock-item'}${isActive ? ' active' : ''}`}
     >
-      <Icon size={expanded ? 20 : 19}/><span>{label}</span>
+      <Icon size={drawer ? 19 : 18}/><span>{label}</span>
     </NavLink>
   )
 
@@ -61,15 +62,14 @@ export function Shell() {
         <button
           className="mobile-dock-handle"
           type="button"
-          aria-label={mobileOpen ? '收起全部导航' : '展开全部导航'}
+          aria-label={mobileOpen ? '收起更多导航' : '展开更多导航'}
           aria-expanded={mobileOpen}
           onClick={() => setMobileOpen(value => !value)}
         >
-          <span/><ChevronUp size={16}/>
+          <ChevronUp size={12}/>
         </button>
         <div className="mobile-drawer" aria-hidden={!mobileOpen}>
-          <div className="mobile-drawer-title"><b>全部功能</b><span>向下滑动收起</span></div>
-          <div className="mobile-drawer-grid">{items.map(item => renderItem(item, true))}</div>
+          <div className="mobile-drawer-grid">{drawerItems.map(item => renderItem(item, true))}</div>
         </div>
         <div className="mobile-dock-row">{compactItems.map(item => renderItem(item))}</div>
       </nav>

--- a/apps/web/src/pages/Converter.css
+++ b/apps/web/src/pages/Converter.css
@@ -118,7 +118,7 @@
   .converter-card>.converter-result small,
   .converter-card>.converter-result strong{white-space:normal}
 
-  .input-card .converter-live-result{padding:12px 14px 12px 16px;border-left:0}
+  form.input-card .live-result.converter-live-result{padding:12px 14px 12px 18px;border-left:0}
   .converter-actions .icon-button{display:grid!important;width:36px;height:36px}
   .buy-button{height:36px}
   .purchase-toast{right:15px;bottom:96px}
@@ -154,6 +154,7 @@
     padding-top:11px;
   }
 
+  form.input-card .live-result.converter-live-result{padding-left:18px}
   .purchase-toast{grid-template-columns:1fr auto}
   .purchase-toast>button{grid-column:2;grid-row:1;align-self:start}
   .purchase-toast>a{grid-column:1/3;text-align:center}


### PR DESCRIPTION
Fixes the latest mobile acceptance issues:

- compact mobile dock always exposes exactly 4 common destinations
- expanding/up-swiping now reveals only the 3 additional destinations, so there are 7 unique entries total rather than 11 rendered entries
- shrink the centered chevron handle so it visually merges into the dock's top edge
- restyle the bottom dock as a lighter floating frosted-glass navigation surface with softer shadow and active states
- keep tap and swipe-to-expand/collapse interactions
- raise selector specificity for the converter work-time preview so its left inset is no longer overwritten by the global mobile `.live-result` rule

Also verified the existing PWA service worker is network-first, so installed iPhone home-screen users do not need to re-add the app after normal deployments.