### PR TITLE
chore: publish Android tags to Releases and refresh README

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -51,16 +51,58 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew assembleDebug --no-daemon
-      - name: Prepare APK artifact
+      - name: Prepare APK files
+        id: package
+        shell: bash
         run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            APK_BASENAME="money-dance-${GITHUB_REF_NAME}"
+          else
+            APK_BASENAME="money-dance-android"
+          fi
+
           mkdir -p artifacts
-          cp apps/web/android/app/build/outputs/apk/debug/app-debug.apk artifacts/money-dance-android.apk
-          sha256sum artifacts/money-dance-android.apk > artifacts/money-dance-android.apk.sha256
+          cp apps/web/android/app/build/outputs/apk/debug/app-debug.apk "artifacts/${APK_BASENAME}.apk"
+          sha256sum "artifacts/${APK_BASENAME}.apk" > "artifacts/${APK_BASENAME}.apk.sha256"
+          echo "apk_name=${APK_BASENAME}.apk" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: money-dance-android-apk
           path: |
-            artifacts/money-dance-android.apk
-            artifacts/money-dance-android.apk.sha256
+            artifacts/*.apk
+            artifacts/*.sha256
           if-no-files-found: error
           retention-days: 30
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: android-apk
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download APK artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p release
+          gh run download "$GITHUB_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name money-dance-android-apk \
+            --dir release
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="$GITHUB_REF_NAME"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$TAG" release/* --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$TAG" release/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --generate-notes \
+              --title "Money Dance $TAG"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,57 +1,217 @@
-# Money Dance / 薪流
+<div align="center">
 
-把工资变成一个实时流动的数字：实时薪资、购买时间换算、摸鱼收益、物品持有成本。
+# 💸 Money Dance / 薪流
 
-## Monorepo
+**把工资从一个月末数字，变成此刻正在流动的钱。**
 
-- `apps/web` — React + Vite + TypeScript，面向 Cloudflare Pages
-- `apps/api` — Hono + TypeScript，面向 Vercel
-- `packages/core` — 前后端共享计算规则与类型
-- `docs` — PRD、信息架构、页面原型与异常场景
+实时薪资 · 心愿清单 · 摸鱼收益 · 收支汇算 · 意外收支 · 物品持有成本
+
+[🌐 在线体验](https://money-dance-6gl.pages.dev/) · [📦 Android 下载](https://github.com/cshouuu/money-dance/releases/latest) · [🛠️ GitHub Actions](https://github.com/cshouuu/money-dance/actions)
+
+![CI](https://github.com/cshouuu/money-dance/actions/workflows/ci.yml/badge.svg)
+![Android APK](https://github.com/cshouuu/money-dance/actions/workflows/build-android-apk.yml/badge.svg)
+![Cloudflare Pages](https://github.com/cshouuu/money-dance/actions/workflows/deploy-cloudflare-pages.yml/badge.svg)
+
+</div>
+
+---
+
+## Money Dance 是什么？
+
+Money Dance 是一个围绕「时间 × 工资 × 消费」构建的个人财务小工具。
+
+它不只是告诉你月薪是多少，而是把工资拆成日薪、时薪、分钟薪资和秒薪，让你看到今天已经赚了多少钱、一件东西需要工作多久才能买到，以及一次摸鱼到底“赚”了多少钱。
+
+项目采用 **local-first** 设计：核心薪资配置、心愿、摸鱼、物品和账本数据默认保存在你的设备本地，不要求注册账号。
+
+## 功能
+
+| 模块 | 能做什么 |
+| --- | --- |
+| 💰 实时薪资 | 根据工资、上下班时间、午休和生活成本，实时计算今天已经赚到的钱 |
+| ⏱️ 薪资速率 | 自动换算日薪 / 时薪 / 分钟薪资 / 秒薪 |
+| 🎯 心愿清单 | 把物品价格换算成连续工时和实际工作日，购买后自动进入支出汇算 |
+| 🐟 摸鱼 | 开始 / 结束计时，计算本次摸鱼对应的工资 |
+| 📊 汇算 | 按日 / 月 / 年查看收入、支出、结余和每一笔来源 |
+| ⚡ 意外 | 记录不影响工资计算的意外收入或意外支出 |
+| 📦 我的好物 | 记录已拥有的物品，观察持有时间增长后每小时成本如何下降 |
+| 📱 多端使用 | Web、iPhone PWA、Android APK 共用同一套核心产品逻辑 |
+
+## 直接使用
+
+### Web
+
+直接打开：
+
+**https://money-dance-6gl.pages.dev/**
+
+### iPhone / iPad
+
+不需要 Apple Developer 账号，也不需要 App Store。
+
+1. 使用 Safari 打开 `https://money-dance-6gl.pages.dev/`
+2. 点击「分享」
+3. 选择「添加到主屏幕」
+4. 从桌面打开 Money Dance
+
+安装一次即可。普通 UI 和功能更新后，不需要重新添加到主屏幕；重新打开应用会优先获取最新线上版本。
+
+### Android
+
+推荐直接从 GitHub Releases 下载最新版 APK：
+
+**https://github.com/cshouuu/money-dance/releases/latest**
+
+下载 `money-dance-vX.Y.Z.apk` 后即可安装，不需要 Google Play。
+
+> 当前 CI 产出的 APK 仍使用 Android debug signing，适合直接安装和验收。若要长期对外分发，并让用户稳定地覆盖安装新版本，需要后续配置一套固定的 Release keystore。
+
+## 技术架构
+
+```text
+Money Dance
+├── apps/web                 React + Vite + TypeScript
+│   ├── Web / PWA
+│   └── Capacitor Android UI
+│
+├── apps/api                 Hono + TypeScript
+│   └── Vercel
+│
+├── packages/core            前后端共享计算规则与类型
+│
+└── docs                     产品与移动端文档
+```
+
+### 技术栈
+
+- React
+- TypeScript
+- Vite
+- Capacitor 8
+- Hono
+- npm workspaces
+- Cloudflare Pages
+- Vercel
+- GitHub Actions
 
 ## 本地开发
 
+要求：Node.js 20+。
+
 ```bash
-npm install
+npm ci
 npm run dev:web
+```
+
+启动 API：
+
+```bash
 npm run dev:api
 ```
 
-Web 默认 `http://localhost:5173`，API 使用 Hono/Vercel 本地方式运行。
+默认 Web 地址：
 
-## 构建与测试
+```text
+http://localhost:5173
+```
+
+## 测试与构建
 
 ```bash
 npm test
 npm run typecheck
 npm run build
+npm audit
 ```
+
+主分支和 PR 会通过 GitHub Actions 自动执行依赖审计、测试、类型检查和构建。
+
+## Android APK
+
+Android 使用现有 React/Vite 前端作为唯一 UI，通过 Capacitor 生成原生 Android 工程，因此不需要维护另一套 React Native / Flutter 代码。
+
+本地生成 Android 工程的详细说明见：
+
+[`docs/MOBILE.md`](docs/MOBILE.md)
+
+## 发布新版本
+
+Web 在 `main` 更新后会由 GitHub Actions 自动部署到 Cloudflare Pages。
+
+Android 使用 Git Tag 驱动发布。
+
+例如发布 `v0.2.0`：
+
+```bash
+git checkout main
+git pull
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+之后 GitHub Actions 会自动完成：
+
+```text
+Tag v0.2.0
+   ↓
+构建 Web
+   ↓
+生成 Capacitor Android 工程
+   ↓
+Gradle 构建 APK
+   ↓
+生成 SHA-256
+   ↓
+创建 GitHub Release
+   ↓
+money-dance-v0.2.0.apk
+money-dance-v0.2.0.apk.sha256
+```
+
+因此普通用户以后只需要进入 **Releases** 下载 APK，不需要再到 Actions 页面寻找 artifact。
 
 ## 部署
 
-### Frontend — Cloudflare Pages
+### Web — Cloudflare Pages
 
-- Root directory: repository root (`/`)
 - Build command: `npm run build -w @salary-flow/core && npm run build -w @salary-flow/web`
-- Build output: `apps/web/dist`
-- Environment: `VITE_API_BASE_URL=https://salary-flow-api.vercel.app`
+- Output: `apps/web/dist`
+- Production: `https://money-dance-6gl.pages.dev/`
 
-仓库已包含 GitHub Actions 工作流；配置 Cloudflare 凭证后会自动确保 `money-dance` Pages 项目存在并部署。手动部署命令：
+### API — Vercel
 
-```bash
-npx wrangler pages deploy dist --project-name=money-dance
-```
+- Root Directory: `apps/api`
+- Production API: `https://salary-flow-api.vercel.app`
 
-### Backend — Vercel
+## 数据与隐私
 
-Vercel 项目 Root Directory 设为 `apps/api`。Vercel 的 monorepo 安装会解析根目录 npm workspace，Hono 可作为 Node backend 部署。生产环境建议配置：
+Money Dance 当前采用 local-first 策略。
 
-- `CORS_ORIGIN=https://<your-cloudflare-pages-domain>`
+以下数据默认保存在当前浏览器 / PWA / Android WebView 的本地存储中：
 
-## MVP 数据策略
+- 薪资与工作时间设置
+- 心愿清单
+- 摸鱼记录
+- 意外收支
+- 物品记录
+- 汇算账本
 
-MVP 采用 local-first：工资配置、摸鱼记录、想买物品和已购物品默认存储在用户浏览器 localStorage，不需要注册，也不会把薪资主动上传服务器。API 仅用于共享计算校验/健康检查，并为后续账号与云同步预留接口。
+这些数据不会因为打开 Web 页面就自动上传到服务器。
 
-## Production API
+需要注意：Web、iPhone PWA 和 Android APK 是不同的本地存储容器，目前不会自动跨设备同步数据。
 
-`https://salary-flow-api.vercel.app`
+## Roadmap
+
+- [ ] 固定 Android Release 签名，支持长期覆盖升级
+- [ ] 数据导入 / 导出
+- [ ] 可选云同步
+- [ ] Android 原生分享 / 触觉反馈 / 通知
+- [ ] 更完整的 iOS 原生能力（在具备 Apple Developer 条件后）
+
+---
+
+<div align="center">
+
+**Time is money. Money should dance.**
+
+</div>

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -13,12 +13,40 @@ Money Dance keeps the existing React/Vite application as the single UI/codebase 
 
 The repository contains `.github/workflows/build-android-apk.yml`.
 
-It builds the current web application, creates a Capacitor Android project on the CI runner, synchronizes the web assets, builds an installable APK, and uploads:
+It builds the current web application, creates a Capacitor Android project on the CI runner, synchronizes the web assets, builds an installable APK, and generates a SHA-256 checksum.
+
+### Pull requests and manual builds
+
+PR and manual workflow runs upload an Actions artifact named:
+
+- `money-dance-android-apk`
+
+The artifact contains:
 
 - `money-dance-android.apk`
 - `money-dance-android.apk.sha256`
 
-The first CI package uses Android debug signing so it can be installed directly for device acceptance testing. Do not treat the debug key as the long-term release identity. Before distributing updateable release builds broadly, configure one persistent release keystore through GitHub Actions secrets and switch the workflow to `assembleRelease`.
+This is intended for development and device acceptance testing.
+
+### Tagged releases
+
+Pushing a tag matching `v*` automatically builds the APK and then creates or updates the matching GitHub Release.
+
+For example:
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+The Release receives directly downloadable files:
+
+- `money-dance-v0.2.0.apk`
+- `money-dance-v0.2.0.apk.sha256`
+
+Users should download Android builds from GitHub Releases rather than searching through Actions artifacts.
+
+The current CI package uses Android debug signing so it can be installed directly for device acceptance testing. Do not treat the debug key as the long-term release identity. Before distributing updateable release builds broadly, configure one persistent release keystore through GitHub Actions secrets and switch the workflow to a release signing configuration.
 
 ### Local Android development
 
@@ -28,7 +56,7 @@ Requirements: Node.js 22+, JDK 21, Android SDK / Android Studio.
 npm ci
 npm run build -w @salary-flow/core
 npm run build -w @salary-flow/web
-npm install --no-save --package-lock=false -w @salary-flow/web @capacitor/core@8.5.0 @capacitor/android@8.5.0 @capacitor/cli@8.5.0
+npm install --no-save --package-lock=false @capacitor/core@8.5.0 @capacitor/android@8.5.0 @capacitor/cli@8.5.0
 cd apps/web
 npx cap add android
 npx cap sync android
@@ -39,7 +67,9 @@ The generated `android/` directory is intentionally reproducible from source and
 
 ## iOS without a paid Apple Developer account
 
-The web app is now installable as a PWA from Safari through **Add to Home Screen**. It includes standalone display metadata, viewport safe-area support, an app manifest, icon, and an offline service worker.
+The web app is installable as a PWA from Safari through **Add to Home Screen**. It includes standalone display metadata, viewport safe-area support, an app manifest, icon, and an offline service worker.
+
+Normal UI and feature deployments do not require users to add the PWA to the home screen again. The current service worker uses a network-first strategy, so reopening the installed PWA fetches the current deployed app when the network is available.
 
 A Capacitor iOS project can also be generated later on macOS with Xcode using the same `capacitor.config.json`. A free Apple ID can be used for limited Personal Team device testing; App Store / TestFlight distribution is intentionally out of scope until a paid Apple Developer membership exists.
 


### PR DESCRIPTION
Improve the Android distribution flow and project documentation.

- keep PR/manual Android builds as GitHub Actions artifacts for acceptance testing
- when a `v*` tag is pushed, build a versioned APK and SHA-256 file
- automatically create or update the matching GitHub Release and attach the APK files directly
- keep release write permission isolated to the tag-only release job
- redesign README as a product-facing landing page with features, Web/iPhone/Android usage, architecture, development, deployment, privacy, roadmap and release instructions
- align `docs/MOBILE.md` with the new artifact-vs-Release workflow

Current APK signing remains debug signing; documentation explicitly notes that a persistent release keystore is still required for stable in-place upgrades.