### PR TITLE
fix: proxy Android update checks through backend

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,6 +3,21 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { z } from 'zod'
 
+const GITHUB_LATEST_RELEASE = 'https://api.github.com/repos/cshouuu/money-dance/releases/latest'
+const RELEASE_ASSET_PREFIX = 'https://github.com/cshouuu/money-dance/releases/download/'
+
+interface GitHubReleaseResponse {
+  tag_name?: string
+  name?: string | null
+  body?: string | null
+  html_url?: string
+  published_at?: string | null
+  assets?: Array<{
+    name?: string
+    browser_download_url?: string
+  }>
+}
+
 const profileSchema = z.object({
   salary: z.number().nonnegative(),
   salaryType: z.enum(['monthly','annual','daily','hourly']),
@@ -13,6 +28,45 @@ const profileSchema = z.object({
 const app = new Hono().basePath('/api')
 app.use('*', cors({ origin: process.env.CORS_ORIGIN || '*', allowMethods: ['GET','POST','OPTIONS'], allowHeaders:['Content-Type'] }))
 app.get('/health', c => c.json({ ok: true, service: 'salary-flow-api', version: '0.1.0', now: new Date().toISOString() }))
+app.get('/app-release/latest', async c => {
+  try {
+    const response = await fetch(GITHUB_LATEST_RELEASE, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'money-dance-api',
+      },
+    })
+    if (response.status === 404) return c.json({ ok: true, data: null })
+    if (!response.ok) return c.json({ ok: false, error: `GITHUB_RELEASE_FAILED_${response.status}` }, 502)
+
+    const release = await response.json() as GitHubReleaseResponse
+    const tag = release.tag_name ?? ''
+    const apk = release.assets?.find(asset => {
+      const url = asset.browser_download_url ?? ''
+      return asset.name?.endsWith('.apk') && url.startsWith(RELEASE_ASSET_PREFIX)
+    })
+
+    if (!tag || !apk?.name || !apk.browser_download_url) return c.json({ ok: true, data: null })
+
+    c.header('Cache-Control', 'public, max-age=60, s-maxage=300, stale-while-revalidate=3600')
+    return c.json({
+      ok: true,
+      data: {
+        tag,
+        version: tag.trim().replace(/^v/i, '').split('-')[0],
+        title: release.name || `Money Dance ${tag}`,
+        notes: release.body || '',
+        apkName: apk.name,
+        apkUrl: apk.browser_download_url,
+        htmlUrl: release.html_url || 'https://github.com/cshouuu/money-dance/releases/latest',
+        publishedAt: release.published_at || '',
+      },
+    })
+  } catch (error) {
+    console.error('app-release/latest failed', error)
+    return c.json({ ok: false, error: 'RELEASE_PROXY_UNAVAILABLE' }, 502)
+  }
+})
 app.post('/calculate/rates', async c => {
   try { const body = profileSchema.parse(await c.req.json()) as SalaryProfile; return c.json({ ok:true, data:calculateRates(body) }) }
   catch (error) { return c.json({ ok:false, error:error instanceof Error?error.message:'Invalid request' }, 400) }

--- a/apps/web/src/lib/appUpdate.ts
+++ b/apps/web/src/lib/appUpdate.ts
@@ -1,4 +1,4 @@
-const RELEASES_API = 'https://api.github.com/repos/cshouuu/money-dance/releases/latest'
+const RELEASES_PROXY_API = 'https://salary-flow-api.vercel.app/api/app-release/latest'
 const RELEASE_ASSET_PREFIX = 'https://github.com/cshouuu/money-dance/releases/download/'
 
 interface CapacitorBridge {
@@ -28,16 +28,10 @@ export interface AndroidRelease {
   publishedAt: string
 }
 
-interface GitHubReleaseResponse {
-  tag_name?: string
-  name?: string | null
-  body?: string | null
-  html_url?: string
-  published_at?: string | null
-  assets?: Array<{
-    name?: string
-    browser_download_url?: string
-  }>
+interface ReleaseProxyResponse {
+  ok?: boolean
+  data?: AndroidRelease | null
+  error?: string
 }
 
 interface NativeUpdateResult {
@@ -87,31 +81,32 @@ export function compareVersions(left: string, right: string) {
   return 0
 }
 
+function isTrustedRelease(release: AndroidRelease) {
+  return Boolean(
+    release.tag &&
+    release.version &&
+    release.apkName?.endsWith('.apk') &&
+    release.apkUrl?.startsWith(RELEASE_ASSET_PREFIX),
+  )
+}
+
 export async function fetchLatestAndroidRelease(): Promise<AndroidRelease | null> {
-  const response = await fetch(RELEASES_API, {
-    headers: { Accept: 'application/vnd.github+json' },
-    cache: 'no-store',
-  })
-  if (response.status === 404) return null
-  if (!response.ok) throw new Error(`RELEASE_CHECK_FAILED_${response.status}`)
+  const controller = new AbortController()
+  const timer = window.setTimeout(() => controller.abort(), 10000)
+  try {
+    const response = await fetch(`${RELEASES_PROXY_API}?t=${Date.now()}`, {
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+    if (!response.ok) throw new Error(`RELEASE_PROXY_FAILED_${response.status}`)
 
-  const release = await response.json() as GitHubReleaseResponse
-  const tag = release.tag_name ?? ''
-  const apk = release.assets?.find(asset => {
-    const url = asset.browser_download_url ?? ''
-    return asset.name?.endsWith('.apk') && url.startsWith(RELEASE_ASSET_PREFIX)
-  })
-  if (!tag || !apk?.name || !apk.browser_download_url) return null
-
-  return {
-    tag,
-    version: normalizeVersion(tag),
-    title: release.name || `Money Dance ${tag}`,
-    notes: release.body || '',
-    apkName: apk.name,
-    apkUrl: apk.browser_download_url,
-    htmlUrl: release.html_url || 'https://github.com/cshouuu/money-dance/releases/latest',
-    publishedAt: release.published_at || '',
+    const payload = await response.json() as ReleaseProxyResponse
+    if (!payload.ok) throw new Error(payload.error || 'RELEASE_PROXY_FAILED')
+    if (!payload.data) return null
+    if (!isTrustedRelease(payload.data)) throw new Error('UNTRUSTED_RELEASE_METADATA')
+    return payload.data
+  } finally {
+    window.clearTimeout(timer)
   }
 }
 


### PR DESCRIPTION
Fixes Android in-app update checks failing on real devices.

- add `/api/app-release/latest` to proxy GitHub Release metadata server-side through the existing Vercel API
- stop Android WebView from calling `api.github.com` directly
- add a 10s client timeout and explicit proxy errors
- validate returned APK metadata and keep the trusted GitHub Release download prefix restriction
- cache release metadata briefly on the backend to reduce GitHub API pressure

After merge, v0.2.2 will be published as the recovery build. Users on v0.2.0/v0.2.1 can manually install v0.2.2 over the existing app without uninstalling because the release signing key is unchanged. Then v0.2.3 can be used to re-test in-app update end-to-end.