### PR TITLE
fix: move Android release checks into native layer

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -3,21 +3,6 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { z } from 'zod'
 
-const GITHUB_LATEST_RELEASE = 'https://api.github.com/repos/cshouuu/money-dance/releases/latest'
-const RELEASE_ASSET_PREFIX = 'https://github.com/cshouuu/money-dance/releases/download/'
-
-interface GitHubReleaseResponse {
-  tag_name?: string
-  name?: string | null
-  body?: string | null
-  html_url?: string
-  published_at?: string | null
-  assets?: Array<{
-    name?: string
-    browser_download_url?: string
-  }>
-}
-
 const profileSchema = z.object({
   salary: z.number().nonnegative(),
   salaryType: z.enum(['monthly','annual','daily','hourly']),
@@ -28,45 +13,6 @@ const profileSchema = z.object({
 const app = new Hono().basePath('/api')
 app.use('*', cors({ origin: process.env.CORS_ORIGIN || '*', allowMethods: ['GET','POST','OPTIONS'], allowHeaders:['Content-Type'] }))
 app.get('/health', c => c.json({ ok: true, service: 'salary-flow-api', version: '0.1.0', now: new Date().toISOString() }))
-app.get('/app-release/latest', async c => {
-  try {
-    const response = await fetch(GITHUB_LATEST_RELEASE, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'money-dance-api',
-      },
-    })
-    if (response.status === 404) return c.json({ ok: true, data: null })
-    if (!response.ok) return c.json({ ok: false, error: `GITHUB_RELEASE_FAILED_${response.status}` }, 502)
-
-    const release = await response.json() as GitHubReleaseResponse
-    const tag = release.tag_name ?? ''
-    const apk = release.assets?.find(asset => {
-      const url = asset.browser_download_url ?? ''
-      return asset.name?.endsWith('.apk') && url.startsWith(RELEASE_ASSET_PREFIX)
-    })
-
-    if (!tag || !apk?.name || !apk.browser_download_url) return c.json({ ok: true, data: null })
-
-    c.header('Cache-Control', 'public, max-age=60, s-maxage=300, stale-while-revalidate=3600')
-    return c.json({
-      ok: true,
-      data: {
-        tag,
-        version: tag.trim().replace(/^v/i, '').split('-')[0],
-        title: release.name || `Money Dance ${tag}`,
-        notes: release.body || '',
-        apkName: apk.name,
-        apkUrl: apk.browser_download_url,
-        htmlUrl: release.html_url || 'https://github.com/cshouuu/money-dance/releases/latest',
-        publishedAt: release.published_at || '',
-      },
-    })
-  } catch (error) {
-    console.error('app-release/latest failed', error)
-    return c.json({ ok: false, error: 'RELEASE_PROXY_UNAVAILABLE' }, 502)
-  }
-})
 app.post('/calculate/rates', async c => {
   try { const body = profileSchema.parse(await c.req.json()) as SalaryProfile; return c.json({ ok:true, data:calculateRates(body) }) }
   catch (error) { return c.json({ ok:false, error:error instanceof Error?error.message:'Invalid request' }, 400) }

--- a/apps/web/native/android/AppUpdaterPlugin.java
+++ b/apps/web/native/android/AppUpdaterPlugin.java
@@ -17,11 +17,37 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
 @CapacitorPlugin(name = "AppUpdater")
 public class AppUpdaterPlugin extends Plugin {
     private static final String APK_MIME = "application/vnd.android.package-archive";
     private static final String RELEASE_HOST = "github.com";
     private static final String RELEASE_PATH_PREFIX = "/cshouuu/money-dance/releases/download/";
+    private static final String RELEASES_API = "https://api.github.com/repos/cshouuu/money-dance/releases/latest";
+
+    private boolean isTrustedReleaseUri(Uri uri) {
+        return "https".equalsIgnoreCase(uri.getScheme())
+                && RELEASE_HOST.equalsIgnoreCase(uri.getHost())
+                && uri.getPath() != null
+                && uri.getPath().startsWith(RELEASE_PATH_PREFIX);
+    }
+
+    private String readBody(InputStream input) throws Exception {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input, "UTF-8"));
+        StringBuilder body = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) body.append(line);
+        reader.close();
+        return body.toString();
+    }
 
     @PluginMethod
     public void getVersion(PluginCall call) {
@@ -38,15 +64,80 @@ public class AppUpdaterPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void getLatestRelease(PluginCall call) {
+        new Thread(() -> {
+            HttpURLConnection connection = null;
+            try {
+                connection = (HttpURLConnection) new URL(RELEASES_API).openConnection();
+                connection.setRequestMethod("GET");
+                connection.setConnectTimeout(10000);
+                connection.setReadTimeout(10000);
+                connection.setRequestProperty("Accept", "application/vnd.github+json");
+                connection.setRequestProperty("User-Agent", "Money-Dance-Android");
+
+                int status = connection.getResponseCode();
+                if (status == 404) {
+                    JSObject result = new JSObject();
+                    result.put("found", false);
+                    call.resolve(result);
+                    return;
+                }
+                if (status < 200 || status >= 300) {
+                    call.reject("Release check failed with HTTP " + status);
+                    return;
+                }
+
+                JSONObject release = new JSONObject(readBody(connection.getInputStream()));
+                String tag = release.optString("tag_name", "");
+                JSONArray assets = release.optJSONArray("assets");
+                String apkName = "";
+                String apkUrl = "";
+                if (assets != null) {
+                    for (int i = 0; i < assets.length(); i++) {
+                        JSONObject asset = assets.optJSONObject(i);
+                        if (asset == null) continue;
+                        String name = asset.optString("name", "");
+                        String url = asset.optString("browser_download_url", "");
+                        if (name.endsWith(".apk") && isTrustedReleaseUri(Uri.parse(url))) {
+                            apkName = name;
+                            apkUrl = url;
+                            break;
+                        }
+                    }
+                }
+
+                JSObject result = new JSObject();
+                if (tag.isEmpty() || apkName.isEmpty() || apkUrl.isEmpty()) {
+                    result.put("found", false);
+                    call.resolve(result);
+                    return;
+                }
+
+                result.put("found", true);
+                result.put("tag", tag);
+                result.put("version", tag.replaceFirst("(?i)^v", "").split("-")[0]);
+                result.put("title", release.optString("name", "Money Dance " + tag));
+                result.put("notes", release.optString("body", ""));
+                result.put("apkName", apkName);
+                result.put("apkUrl", apkUrl);
+                result.put("htmlUrl", release.optString("html_url", "https://github.com/cshouuu/money-dance/releases/latest"));
+                result.put("publishedAt", release.optString("published_at", ""));
+                call.resolve(result);
+            } catch (Exception error) {
+                call.reject("Unable to check latest release", error);
+            } finally {
+                if (connection != null) connection.disconnect();
+            }
+        }, "money-dance-update-check").start();
+    }
+
+    @PluginMethod
     public void downloadAndInstall(PluginCall call) {
         String url = call.getString("url", "");
         String fileName = call.getString("fileName", "money-dance-update.apk");
         Uri uri = Uri.parse(url);
 
-        if (!"https".equalsIgnoreCase(uri.getScheme())
-                || !RELEASE_HOST.equalsIgnoreCase(uri.getHost())
-                || uri.getPath() == null
-                || !uri.getPath().startsWith(RELEASE_PATH_PREFIX)) {
+        if (!isTrustedReleaseUri(uri)) {
             call.reject("Untrusted update URL");
             return;
         }

--- a/apps/web/src/lib/appUpdate.ts
+++ b/apps/web/src/lib/appUpdate.ts
@@ -1,4 +1,3 @@
-const RELEASES_PROXY_API = 'https://salary-flow-api.vercel.app/api/app-release/latest'
 const RELEASE_ASSET_PREFIX = 'https://github.com/cshouuu/money-dance/releases/download/'
 
 interface CapacitorBridge {
@@ -28,10 +27,8 @@ export interface AndroidRelease {
   publishedAt: string
 }
 
-interface ReleaseProxyResponse {
-  ok?: boolean
-  data?: AndroidRelease | null
-  error?: string
+interface NativeReleaseResult extends Partial<AndroidRelease> {
+  found: boolean
 }
 
 interface NativeUpdateResult {
@@ -81,32 +78,33 @@ export function compareVersions(left: string, right: string) {
   return 0
 }
 
-function isTrustedRelease(release: AndroidRelease) {
+function isTrustedRelease(release: NativeReleaseResult): release is NativeReleaseResult & AndroidRelease {
   return Boolean(
+    release.found &&
     release.tag &&
     release.version &&
+    release.title !== undefined &&
+    release.notes !== undefined &&
     release.apkName?.endsWith('.apk') &&
-    release.apkUrl?.startsWith(RELEASE_ASSET_PREFIX),
+    release.apkUrl?.startsWith(RELEASE_ASSET_PREFIX) &&
+    release.htmlUrl !== undefined &&
+    release.publishedAt !== undefined,
   )
 }
 
 export async function fetchLatestAndroidRelease(): Promise<AndroidRelease | null> {
-  const controller = new AbortController()
-  const timer = window.setTimeout(() => controller.abort(), 10000)
-  try {
-    const response = await fetch(`${RELEASES_PROXY_API}?t=${Date.now()}`, {
-      cache: 'no-store',
-      signal: controller.signal,
-    })
-    if (!response.ok) throw new Error(`RELEASE_PROXY_FAILED_${response.status}`)
-
-    const payload = await response.json() as ReleaseProxyResponse
-    if (!payload.ok) throw new Error(payload.error || 'RELEASE_PROXY_FAILED')
-    if (!payload.data) return null
-    if (!isTrustedRelease(payload.data)) throw new Error('UNTRUSTED_RELEASE_METADATA')
-    return payload.data
-  } finally {
-    window.clearTimeout(timer)
+  const release = await nativeCall<NativeReleaseResult>('getLatestRelease')
+  if (!release.found) return null
+  if (!isTrustedRelease(release)) throw new Error('UNTRUSTED_RELEASE_METADATA')
+  return {
+    tag: release.tag,
+    version: release.version,
+    title: release.title,
+    notes: release.notes,
+    apkName: release.apkName,
+    apkUrl: release.apkUrl,
+    htmlUrl: release.htmlUrl,
+    publishedAt: release.publishedAt,
   }
 }
 


### PR DESCRIPTION
Replaces the WebView/Vercel update metadata path with a fully native Android release check.

- add `AppUpdater.getLatestRelease` in Java using `HttpURLConnection` to GitHub Releases
- perform release lookup off the UI thread with 10s connect/read timeouts
- validate the release APK host/path natively before returning metadata
- make the React update service call the native bridge instead of `fetch`
- remove the temporary Vercel release proxy endpoint because the API project is not Git-linked and the proxy is no longer needed
- keep APK downloads and install permission handling in the existing native updater

This specifically addresses real-device update checks failing from the Android WebView.