### PR TITLE
fix: register Android AppUpdater before Capacitor bridge creation

### DIFF
--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -128,6 +128,26 @@ jobs:
           ANDROID_VERSION_CODE: ${{ steps.version.outputs.version_code }}
           ANDROID_RELEASE_SIGNING: 'true'
         run: node apps/web/native/android/prepare-android.mjs
+      - name: Verify AppUpdater native registration
+        shell: bash
+        run: |
+          set -euo pipefail
+          MAIN_ACTIVITY="apps/web/android/app/src/main/java/com/cshouuu/moneydance/MainActivity.java"
+          PLUGIN_SOURCE="apps/web/android/app/src/main/java/com/cshouuu/moneydance/AppUpdaterPlugin.java"
+          test -f "$MAIN_ACTIVITY"
+          test -f "$PLUGIN_SOURCE"
+          grep -Fq '@CapacitorPlugin(name = "AppUpdater")' "$PLUGIN_SOURCE"
+          node - "$MAIN_ACTIVITY" <<'NODE'
+          const fs = require('fs')
+          const source = fs.readFileSync(process.argv[2], 'utf8')
+          const registerAt = source.indexOf('registerPlugin(AppUpdaterPlugin.class)')
+          const superAt = source.indexOf('super.onCreate(savedInstanceState)')
+          if (registerAt < 0 || superAt < 0 || registerAt > superAt) {
+            console.error('AppUpdater must be registered before BridgeActivity creates the Capacitor Bridge')
+            process.exit(1)
+          }
+          console.log('AppUpdater registration order verified')
+          NODE
       - name: Build APK
         working-directory: apps/web/android
         shell: bash

--- a/apps/web/native/android/prepare-android.mjs
+++ b/apps/web/native/android/prepare-android.mjs
@@ -25,8 +25,10 @@ import com.getcapacitor.BridgeActivity;
 public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+        // Capacitor builds the Bridge during super.onCreate(), so custom plugins
+        // must be registered first or they will not exist at runtime.
         registerPlugin(AppUpdaterPlugin.class);
+        super.onCreate(savedInstanceState);
     }
 }
 `)


### PR DESCRIPTION
## What changed
- register `AppUpdaterPlugin` before `super.onCreate(...)` in generated `MainActivity`
- add CI validation that the custom plugin source exists and is registered before Capacitor creates the Bridge

## Why
The Android app currently fails at runtime with `unable to find plugin : AppUpdater`. Capacitor builds its Bridge during `super.onCreate(...)`, so registering the plugin afterwards is too late even though the APK compiles successfully.

## Validation
- normal web CI
- Android project generation
- explicit AppUpdater registration-order check
- Gradle APK build
- APK signature verification