### PR TITLE
fix: keep slacking delete actions visible on mobile

### DIFF
--- a/apps/web/src/pages/Slacking.css
+++ b/apps/web/src/pages/Slacking.css
@@ -1,11 +1,11 @@
 .clear-slacking-button:disabled{cursor:not-allowed;opacity:.42}
-.slacking-delete-button{display:grid}
+.slacking-record>.slacking-delete-button{display:grid!important}
 
 @media(max-width:560px){
   .slacking-summary{display:grid;grid-template-columns:1fr 1fr;gap:14px 18px;align-items:start}
-  .slacking-summary .clear-slacking-button{display:flex;grid-column:1/3;width:100%;margin:0;padding:12px 0 0;justify-content:center;border-top:1px solid var(--line)}
+  .slacking-summary.summary-strip .clear-slacking-button.text-button{display:flex!important;grid-column:1/3;width:100%;margin:0;padding:12px 0 0;justify-content:center;border-top:1px solid var(--line)}
   .slacking-record{grid-template-columns:40px minmax(0,1fr) auto 36px;gap:9px}
-  .slacking-record>.slacking-delete-button{display:grid;width:36px;height:36px}
+  .slacking-record>.slacking-delete-button{display:grid!important;width:36px;height:36px}
   .slacking-record .item-main{min-width:0}
   .slacking-record .item-main b{overflow-wrap:anywhere}
 }


### PR DESCRIPTION
## Fix

The mobile global stylesheet hides direct `.icon-button` children and summary `.text-button` actions below 560px. Those selectors were loaded after the slacking page stylesheet and won the equal-specificity cascade.

This change gives the two intended slacking actions explicit, page-scoped mobile overrides:

- per-session delete button stays visible
- clear-all history button stays visible
- existing compact card layout remains unchanged

The confirmation behavior and requested copy are unchanged.