### PR TITLE
fix: 调整移动端常驻导航

### DIFF
--- a/apps/web/src/components/Shell.tsx
+++ b/apps/web/src/components/Shell.tsx
@@ -5,11 +5,11 @@ import './Shell.css'
 
 const items = [
   ['/', Coins, '今日', true],
-  ['/convert', Clock3, '换算', true],
-  ['/summary', BarChart3, '账本', true],
+  ['/convert', Clock3, '换算', false],
+  ['/summary', BarChart3, '账本', false],
   ['/accidents', CircleDollarSign, '意外', false],
-  ['/slacking', Fish, '摸鱼', false],
-  ['/overtime', BriefcaseBusiness, '加班', false],
+  ['/slacking', Fish, '摸鱼', true],
+  ['/overtime', BriefcaseBusiness, '加班', true],
   ['/attendance', CalendarCheck2, '薪苦', false],
   ['/assets', Boxes, '物品', false],
   ['/settings', Settings2, '我的', true],


### PR DESCRIPTION
## 调整
- 移动端常驻 Tab 改为：今日、摸鱼、加班、我的
- 换算、账本移入上拉的更多导航
- 桌面端导航保持原有顺序和内容

## 验证
- `npm run typecheck`
- `npm test`（12 tests passed）
- `npm run build`
- `git diff --check`