### PR TITLE
fix: 修复 R2 APK 下载响应

### DIFF
--- a/apps/web/functions/download/[[path]].js
+++ b/apps/web/functions/download/[[path]].js
@@ -10,50 +10,61 @@ function json(data, status = 200, cacheControl = 'no-store') {
   })
 }
 
-export async function onRequestGet(context) {
+function resolveDownload(pathname) {
+  if (pathname === '/download/latest.json') {
+    return { key: 'latest.json', cacheControl: 'no-store', downloadFileName: null }
+  }
+
+  if (pathname.startsWith('/download/releases/')) {
+    const fileName = decodeURIComponent(pathname.slice('/download/releases/'.length))
+    if (!APK_NAME.test(fileName)) return null
+    return {
+      key: `releases/${fileName}`,
+      cacheControl: 'public, max-age=31536000, immutable',
+      downloadFileName: fileName,
+    }
+  }
+
+  return null
+}
+
+async function handleRequest(context, headOnly) {
   const url = new URL(context.request.url)
   const pathname = url.pathname
 
   if (pathname === '/download/health') {
+    if (headOnly) {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' },
+      })
+    }
     return json({ ok: true, source: 'cloudflare-pages-r2' }, 200, 'no-store')
   }
 
-  let key
-  let cacheControl
-  let downloadFileName = null
+  const download = resolveDownload(pathname)
+  if (!download) return new Response(headOnly ? null : 'Not found', { status: 404 })
 
-  if (pathname === '/download/latest.json') {
-    key = 'latest.json'
-    cacheControl = 'no-store'
-  } else if (pathname.startsWith('/download/releases/')) {
-    const fileName = decodeURIComponent(pathname.slice('/download/releases/'.length))
-    if (!APK_NAME.test(fileName)) return new Response('Not found', { status: 404 })
-    key = `releases/${fileName}`
-    cacheControl = 'public, max-age=31536000, immutable'
-    downloadFileName = fileName
-  } else {
-    return new Response('Not found', { status: 404 })
-  }
-
-  const object = await context.env.RELEASES.get(key, {
-    range: context.request.headers,
-  })
-  if (!object) return new Response('Not found', { status: 404 })
+  const rangeHeader = headOnly ? null : context.request.headers.get('range')
+  const object = headOnly
+    ? await context.env.RELEASES.head(download.key)
+    : await context.env.RELEASES.get(download.key, rangeHeader ? { range: context.request.headers } : undefined)
+  if (!object) return new Response(headOnly ? null : 'Not found', { status: 404 })
 
   const headers = new Headers()
   object.writeHttpMetadata(headers)
   headers.set('etag', object.httpEtag)
   headers.set('accept-ranges', 'bytes')
-  headers.set('cache-control', cacheControl)
+  headers.set('cache-control', download.cacheControl)
   headers.set('x-content-type-options', 'nosniff')
 
-  if (downloadFileName) {
+  if (download.downloadFileName) {
     headers.set('content-type', 'application/vnd.android.package-archive')
-    headers.set('content-disposition', `attachment; filename="${downloadFileName}"`)
+    headers.set('content-disposition', `attachment; filename="${download.downloadFileName}"`)
   }
 
   let status = 200
-  if (object.range) {
+  if (!headOnly && rangeHeader && object.range) {
     const offset = object.range.offset ?? 0
     const length = object.range.length ?? object.size
     const end = offset + length - 1
@@ -64,5 +75,13 @@ export async function onRequestGet(context) {
     headers.set('content-length', String(object.size))
   }
 
-  return new Response(object.body, { status, headers })
+  return new Response(headOnly ? null : object.body, { status, headers })
+}
+
+export function onRequestGet(context) {
+  return handleRequest(context, false)
+}
+
+export function onRequestHead(context) {
+  return handleRequest(context, true)
 }

--- a/apps/web/scripts/verify-pwa-build.mjs
+++ b/apps/web/scripts/verify-pwa-build.mjs
@@ -30,4 +30,45 @@ const javascriptAsset = await onRequest({
 })
 assert.equal(javascriptAsset.status, 200, 'valid static assets must pass through unchanged')
 
+const { onRequestGet, onRequestHead } = await import('../functions/download/[[path]].js')
+const calls = []
+const releaseObject = range => ({
+  body: new Uint8Array([80, 75, 3, 4]),
+  size: 4,
+  range,
+  httpEtag: 'test-etag',
+  writeHttpMetadata(headers) {
+    headers.set('content-type', 'application/octet-stream')
+  },
+})
+const releases = {
+  async get(key, options) {
+    calls.push({ method: 'get', key, options })
+    return releaseObject(options ? { offset: 0, length: 2 } : undefined)
+  },
+  async head(key) {
+    calls.push({ method: 'head', key })
+    return releaseObject(undefined)
+  },
+}
+const downloadUrl = 'https://example.com/download/releases/money-dance-v0.2.20.apk'
+
+const fullDownload = await onRequestGet({ request: new Request(downloadUrl), env: { RELEASES: releases } })
+assert.equal(fullDownload.status, 200, 'normal APK downloads must return 200')
+assert.equal(fullDownload.headers.get('content-range'), null, 'normal downloads must not include Content-Range')
+assert.equal(calls[0].options, undefined, 'normal downloads must not send an empty range option to R2')
+
+const partialDownload = await onRequestGet({
+  request: new Request(downloadUrl, { headers: { range: 'bytes=0-1' } }),
+  env: { RELEASES: releases },
+})
+assert.equal(partialDownload.status, 206, 'range downloads must return 206')
+assert.equal(partialDownload.headers.get('content-range'), 'bytes 0-1/4')
+
+const downloadHead = await onRequestHead({ request: new Request(downloadUrl, { method: 'HEAD' }), env: { RELEASES: releases } })
+assert.equal(downloadHead.status, 200, 'APK HEAD requests must return file metadata')
+assert.equal(downloadHead.headers.get('content-type'), 'application/vnd.android.package-archive')
+assert.match(downloadHead.headers.get('content-disposition') || '', /attachment/)
+assert.equal(calls.at(-1).method, 'head', 'HEAD requests must use R2 metadata without downloading the body')
+
 console.log(`PWA build verified with ${assetUrls.length} entry assets.`)


### PR DESCRIPTION
## 问题

- 普通完整下载错误返回 `206 Partial Content`
- APK 的 HEAD 请求被 SPA 回退接管，返回网站首页 HTML
- 部分手机浏览器因此不会启动下载，或者直接显示白屏

## 修复

- 没有 Range 请求头时返回 `200 OK`
- 只有断点续传请求返回 `206 Partial Content`
- 新增 HEAD 处理，直接从 R2 读取文件元数据
- APK 始终返回正确 MIME 与 attachment 文件名
- 增加完整下载、Range 下载和 HEAD 请求的构建校验

## 验证

- Web 构建及 PWA 校验通过
- 12 项测试通过
- 全仓类型检查通过