### PR TITLE
fix: make APK link work in browsers

### DIFF
--- a/apps/web/functions/download/[[path]].js
+++ b/apps/web/functions/download/[[path]].js
@@ -1,5 +1,59 @@
 const APK_NAME = /^money-dance-v\d+\.\d+\.\d+\.apk$/
 
+function escapeHtml(value) {
+  return value.replace(/[&<>"']/g, character => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[character])
+}
+
+function isBrowserNavigation(request, url, download) {
+  if (!download.downloadFileName || url.searchParams.get('raw') === '1') return false
+  if (request.headers.has('range')) return false
+  return request.headers.get('sec-fetch-dest') === 'document'
+    || request.headers.get('sec-fetch-mode') === 'navigate'
+}
+
+function downloadPage(url, fileName) {
+  const rawUrl = escapeHtml(`${url.pathname}?raw=1`)
+  const safeFileName = escapeHtml(fileName)
+  const version = escapeHtml(fileName.replace(/^money-dance-|\.apk$/g, ''))
+
+  return new Response(`<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#1d2a20">
+  <title>下载 Money Dance ${version}</title>
+  <style>
+    *{box-sizing:border-box}body{margin:0;min-height:100vh;display:grid;place-items:center;padding:24px;background:#f4f1e8;color:#18211a;font-family:Inter,"PingFang SC","Microsoft YaHei",sans-serif}main{width:min(100%,440px);padding:36px 28px;border:1px solid rgba(29,42,32,.12);border-radius:28px;background:#fffdf7;box-shadow:0 18px 60px rgba(29,42,32,.1)}small{color:#70806f;letter-spacing:.16em}h1{margin:12px 0 10px;font-size:36px;line-height:1.15}p{margin:0 0 26px;color:#697168;line-height:1.7}.button{display:flex;align-items:center;justify-content:center;min-height:56px;padding:0 20px;border-radius:16px;background:#1d2a20;color:#fffdf7;font-weight:700;text-decoration:none}.hint{margin:14px 0 0;font-size:13px;text-align:center}
+  </style>
+</head>
+<body>
+  <main>
+    <small>MONEY DANCE · ANDROID</small>
+    <h1>安装包已准备好</h1>
+    <p>${safeFileName}</p>
+    <a id="download" class="button" href="${rawUrl}" download="${safeFileName}">下载安装包</a>
+    <p class="hint">如果没有自动开始，请点击上方按钮</p>
+  </main>
+  <script>setTimeout(()=>document.querySelector('#download').click(),300)</script>
+</body>
+</html>`, {
+    status: 200,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
+      'vary': 'Sec-Fetch-Dest, Sec-Fetch-Mode',
+    },
+  })
+}
+
 function json(data, status = 200, cacheControl = 'no-store') {
   return new Response(JSON.stringify(data), {
     status,
@@ -45,6 +99,10 @@ async function handleRequest(context, headOnly) {
   const download = resolveDownload(pathname)
   if (!download) return new Response(headOnly ? null : 'Not found', { status: 404 })
 
+  if (!headOnly && isBrowserNavigation(context.request, url, download)) {
+    return downloadPage(url, download.downloadFileName)
+  }
+
   const rangeHeader = headOnly ? null : context.request.headers.get('range')
   const object = headOnly
     ? await context.env.RELEASES.head(download.key)
@@ -57,6 +115,7 @@ async function handleRequest(context, headOnly) {
   headers.set('accept-ranges', 'bytes')
   headers.set('cache-control', download.cacheControl)
   headers.set('x-content-type-options', 'nosniff')
+  headers.set('vary', 'Sec-Fetch-Dest, Sec-Fetch-Mode')
 
   if (download.downloadFileName) {
     headers.set('content-type', 'application/vnd.android.package-archive')

--- a/apps/web/scripts/verify-pwa-build.mjs
+++ b/apps/web/scripts/verify-pwa-build.mjs
@@ -53,10 +53,32 @@ const releases = {
 }
 const downloadUrl = 'https://example.com/download/releases/money-dance-v0.2.20.apk'
 
+const browserDownload = await onRequestGet({
+  request: new Request(downloadUrl, {
+    headers: { 'sec-fetch-dest': 'document', 'sec-fetch-mode': 'navigate' },
+  }),
+  env: { RELEASES: releases },
+})
+assert.equal(browserDownload.status, 200, 'browser navigation must return a download page')
+assert.match(browserDownload.headers.get('content-type') || '', /^text\/html/, 'browser download page must return HTML')
+const browserDownloadHtml = await browserDownload.text()
+assert.match(browserDownloadHtml, /\?raw=1/, 'browser download page must link to the raw APK')
+assert.match(browserDownloadHtml, /download="money-dance-v0\.2\.20\.apk"/, 'browser download page must use the download attribute')
+assert.equal(calls.length, 0, 'browser download page must not stream the APK before the user starts the download')
+
+const rawBrowserDownload = await onRequestGet({
+  request: new Request(`${downloadUrl}?raw=1`, {
+    headers: { 'sec-fetch-dest': 'document', 'sec-fetch-mode': 'navigate' },
+  }),
+  env: { RELEASES: releases },
+})
+assert.equal(rawBrowserDownload.status, 200, 'raw browser downloads must return the APK')
+assert.equal(rawBrowserDownload.headers.get('content-type'), 'application/vnd.android.package-archive')
+
 const fullDownload = await onRequestGet({ request: new Request(downloadUrl), env: { RELEASES: releases } })
 assert.equal(fullDownload.status, 200, 'normal APK downloads must return 200')
 assert.equal(fullDownload.headers.get('content-range'), null, 'normal downloads must not include Content-Range')
-assert.equal(calls[0].options, undefined, 'normal downloads must not send an empty range option to R2')
+assert.equal(calls[1].options, undefined, 'normal downloads must not send an empty range option to R2')
 
 const partialDownload = await onRequestGet({
   request: new Request(downloadUrl, { headers: { range: 'bytes=0-1' } }),


### PR DESCRIPTION
## What changed
- return a lightweight download page when Chrome/Safari opens an APK URL as a document navigation
- automatically start the same-origin raw APK download and keep a visible retry button
- keep app updater, HEAD requests, and Range downloads streaming the original APK
- vary responses by Fetch Metadata headers to avoid mixing HTML and APK cache entries

## Verification
- web production build and PWA verification pass
- 12 unit tests pass
- workspace typecheck passes
- added coverage for browser navigation and `?raw=1` downloads