### PR TITLE
fix: stop homepage salary calculation on rest days

### DIFF
--- a/apps/web/src/lib/work.test.ts
+++ b/apps/web/src/lib/work.test.ts
@@ -1,0 +1,67 @@
+import { calculateRates, DEFAULT_PROFILE } from '@salary-flow/core'
+import { describe, expect, it } from 'vitest'
+import type { AttendanceRecord, DailyWorkRecord } from '../types'
+import { summarizeTodayWork } from './work'
+
+const profile = {
+  ...DEFAULT_PROFILE,
+  salary: 100,
+  salaryType: 'daily' as const,
+  workDaysPerWeek: 5,
+}
+
+const saturday = new Date(2026, 7, 29, 10, 0, 0)
+const friday = new Date(2026, 7, 28, 10, 0, 0)
+
+function scheduledRecord(): DailyWorkRecord {
+  return { date: '2026-08-29', mode: 'scheduled', status: 'ended', sessions: [], updatedAt: saturday.toISOString() }
+}
+
+function attendance(record: Partial<AttendanceRecord>): AttendanceRecord[] {
+  return [{ date: '2026-08-29', status: 'normal', updatedAt: saturday.toISOString(), ...record }]
+}
+
+describe('today workday rules', () => {
+  it('does not auto-calculate salary on Saturday for a five-day schedule', () => {
+    const summary = summarizeTodayWork(profile, [], saturday)
+    expect(summary.dayType).toBe('rest')
+    expect(summary.earnedAmount).toBe(0)
+    expect(summary.workedSeconds).toBe(0)
+  })
+
+  it('continues auto-calculation on configured weekdays', () => {
+    const summary = summarizeTodayWork(profile, [], friday)
+    expect(summary.dayType).toBe('work')
+    expect(summary.earnedAmount).toBeGreaterThan(0)
+  })
+
+  it('allows Saturday when the profile is configured for six workdays', () => {
+    const summary = summarizeTodayWork({ ...profile, workDaysPerWeek: 6 }, [], saturday)
+    expect(summary.dayType).toBe('work')
+    expect(summary.earnedAmount).toBeGreaterThan(0)
+  })
+
+  it('allows a one-day scheduled override on Saturday', () => {
+    const summary = summarizeTodayWork(profile, [scheduledRecord()], saturday)
+    expect(summary.dayType).toBe('work')
+    expect(summary.earnedAmount).toBeGreaterThan(0)
+  })
+
+  it('allows an explicit normal-attendance override on Saturday', () => {
+    const summary = summarizeTodayWork(profile, [], saturday, undefined, attendance({ status: 'normal' }))
+    expect(summary.dayType).toBe('work')
+    expect(summary.earnedAmount).toBeGreaterThan(0)
+  })
+
+  it('applies unpaid leave before the normal scheduled calculation', () => {
+    const summary = summarizeTodayWork(profile, [scheduledRecord()], saturday, undefined, attendance({ status: 'leave', leaveType: 'personal', payMode: 'unpaid' }))
+    expect(summary.dayType).toBe('leave')
+    expect(summary.earnedAmount).toBe(0)
+  })
+
+  it('applies paid leave using the configured multiplier', () => {
+    const summary = summarizeTodayWork(profile, [], saturday, undefined, attendance({ status: 'leave', leaveType: 'sick', payMode: 'multiplier', multiplier: 0.8 }))
+    expect(summary.dayType).toBe('leave')
+    expect(summary.earnedAmount).toBeCloseTo(calculateRates(profile).daily * 0.8)
+  })
+})

--- a/apps/web/src/lib/work.ts
+++ b/apps/web/src/lib/work.ts
@@ -1,14 +1,17 @@
 import { calculateRates, getWorkedPaidSeconds, type SalaryProfile, type SalaryRates, type WorkMode } from '@salary-flow/core'
-import type { DailyWorkRecord, DailyWorkStatus, WorkSession } from '../types'
+import type { AttendanceRecord, DailyWorkRecord, DailyWorkStatus, WorkSession } from '../types'
+import { isConfiguredWorkday } from './attendance'
 import { localDateWithTime, toLocalDateValue } from './form'
 import { keys, loadJSON, saveJSON } from './storage'
 
 export interface TodayWorkSummary {
   mode: WorkMode
   status: DailyWorkStatus
+  dayType: 'work' | 'rest' | 'leave'
   workedSeconds: number
   earnedAmount: number
   record?: DailyWorkRecord
+  attendance?: AttendanceRecord
 }
 
 export function loadWorkRecords(): DailyWorkRecord[] {
@@ -40,17 +43,50 @@ export function getFlexibleWorkedSeconds(record: DailyWorkRecord, now = new Date
   return Math.min(maximum, total)
 }
 
-export function summarizeTodayWork(profile: SalaryProfile, records: DailyWorkRecord[], now = new Date(), providedRates?: SalaryRates): TodayWorkSummary {
+export function summarizeTodayWork(profile: SalaryProfile, records: DailyWorkRecord[], now = new Date(), providedRates?: SalaryRates, attendanceRecords: AttendanceRecord[] = []): TodayWorkSummary {
   const today = toLocalDateValue(now)
   const record = getWorkRecord(records, today)
+  const attendance = attendanceRecords.find(item => item.date === today)
   const mode = record?.mode ?? profile.defaultWorkMode
   const rates = providedRates ?? calculateRates(profile)
+
+  if (attendance?.status === 'leave') {
+    let earnedAmount = 0
+    if (attendance.payMode === 'multiplier') earnedAmount = rates.daily * Math.max(0, attendance.multiplier ?? 0)
+    if (attendance.payMode === 'fixed') earnedAmount = Math.max(0, attendance.fixedAmount ?? 0)
+    return {
+      mode,
+      status: 'ended',
+      dayType: 'leave',
+      workedSeconds: 0,
+      earnedAmount,
+      record,
+      attendance,
+    }
+  }
+
+  const scheduledWorkday = record?.mode === 'scheduled'
+    || attendance?.status === 'normal'
+    || isConfiguredWorkday(now, profile.workDaysPerWeek)
+  if (mode === 'scheduled' && !scheduledWorkday) {
+    return {
+      mode,
+      status: 'ready',
+      dayType: 'rest',
+      workedSeconds: 0,
+      earnedAmount: 0,
+      record,
+      attendance,
+    }
+  }
+
   const workedSeconds = mode === 'flexible'
     ? record ? getFlexibleWorkedSeconds(record, now, rates.paidSecondsPerDay) : 0
     : getWorkedPaidSeconds(profile, now)
   return {
     mode,
     status: mode === 'flexible' ? record?.status ?? 'ready' : 'working',
+    dayType: 'work',
     workedSeconds,
     earnedAmount: workedSeconds * rates.second,
     record,

--- a/apps/web/src/pages/Dashboard.css
+++ b/apps/web/src/pages/Dashboard.css
@@ -1,2 +1,3 @@
 .dashboard-metric-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.overtime-metric{background:#eee9dc}.overtime-metric .metric-icon{background:#dfe4c6}.overtime-metric>a{display:block;margin-top:14px;color:#4e624a;font-size:11px;font-weight:600;text-decoration:none}
+.dashboard-day-note{position:relative;display:flex;align-items:center;min-height:42px;margin-bottom:6px;padding:0 14px;border:1px solid #3f4b40;border-radius:12px;background:#29342b;color:#b8c1b3;font-size:11px;line-height:1.5}
 @media(max-width:900px){.dashboard-metric-grid{grid-template-columns:1fr}}

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -3,13 +3,14 @@ import { ArrowUpRight, BriefcaseBusiness, Clock3, Fish, Pause, Play, RotateCcw, 
 import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { WorkTimeDialog } from '../components/WorkTimeDialog'
+import { leaveTypeLabel, loadAttendanceRecords } from '../lib/attendance'
 import { toLocalDateValue, toLocalTimeValue } from '../lib/form'
 import { loadProfile } from '../lib/profile'
 import { calculateOvertimeEarnings } from '../lib/overtime'
 import { keys, loadJSON } from '../lib/storage'
 import { useNow } from '../lib/useNow'
 import { closeActiveWorkSession, loadWorkRecords, replaceFlexibleWorkTime, resumeFlexibleWork, saveWorkRecords, scheduledOverride, startFlexibleWork, summarizeTodayWork, upsertWorkRecord } from '../lib/work'
-import type { ActiveOvertime, DailyWorkRecord, OvertimeSession, SlackingSession } from '../types'
+import type { ActiveOvertime, AttendanceRecord, DailyWorkRecord, OvertimeSession, SlackingSession } from '../types'
 import './Dashboard.css'
 
 const money = (n: number) => `¥${n.toLocaleString('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
@@ -25,12 +26,13 @@ export function Dashboard() {
   const now = useNow(1000)
   const [profile] = useState(() => loadProfile())
   const [workRecords, setWorkRecords] = useState<DailyWorkRecord[]>(() => loadWorkRecords())
+  const [attendanceRecords] = useState<AttendanceRecord[]>(() => loadAttendanceRecords())
   const [slackingSessions] = useState<SlackingSession[]>(() => loadJSON<SlackingSession[]>(keys.sessions, []))
   const [overtimeSessions] = useState<OvertimeSession[]>(() => loadJSON<OvertimeSession[]>(keys.overtimeSessions, []))
   const [activeOvertime] = useState<ActiveOvertime | null>(() => loadJSON<ActiveOvertime | null>(keys.activeOvertime, null))
   const [dialogPurpose, setDialogPurpose] = useState<'start' | 'adjust' | null>(null)
   const rates = useMemo(() => calculateRates(profile), [profile])
-  const work = summarizeTodayWork(profile, workRecords, now, rates)
+  const work = summarizeTodayWork(profile, workRecords, now, rates, attendanceRecords)
   const earned = work.earnedAmount
   const worked = work.workedSeconds
   const progress = Math.max(0, Math.min(100, (worked / rates.paidSecondsPerDay) * 100))
@@ -44,6 +46,20 @@ export function Dashboard() {
   const overtimeSeconds = todayOvertime.reduce((total, session) => total + session.durationSeconds, 0) + activeOvertimeSeconds
   const overtimeMoney = todayOvertime.reduce((total, session) => total + session.earnedAmount, 0) + (activeOvertimeToday ? calculateOvertimeEarnings(activeOvertimeToday, activeOvertimeSeconds, rates.second) : 0)
   const firstStart = work.record?.sessions[0]?.startTime
+  const leaveLabel = work.attendance?.status === 'leave' ? leaveTypeLabel(work.attendance.leaveType) : ''
+  const attendancePayLabel = work.attendance?.payMode === 'multiplier'
+    ? `${work.attendance.multiplier ?? 0} 倍计薪`
+    : work.attendance?.payMode === 'fixed'
+      ? `固定 ${money(work.attendance.fixedAmount ?? 0)}`
+      : '不计薪'
+  const heroLabel = work.dayType === 'rest' ? '今天休息' : work.dayType === 'leave' ? '今日出勤调整' : work.mode === 'flexible' ? '今日实际已赚' : '今日已经赚了'
+  const modeStatus = work.dayType === 'rest'
+    ? '非工作日 · 不自动计薪'
+    : work.dayType === 'leave'
+      ? `${leaveLabel} · ${attendancePayLabel}`
+      : work.mode === 'flexible'
+        ? statusLabels[work.status]
+        : '固定作息 · 自动计薪'
 
   const persistRecord = useCallback((record: DailyWorkRecord) => {
     setWorkRecords(current => {
@@ -76,21 +92,26 @@ export function Dashboard() {
   return <section className="page dashboard-page">
     <header className="page-header"><div><p className="eyebrow">{now.toLocaleDateString('zh-CN', { month:'long', day:'numeric', weekday:'long' })}</p><h1>今天的时间，正在变成钱。</h1></div><Link className="ghost-button" to="/settings">薪资设置 <ArrowUpRight size={16}/></Link></header>
 
-    <div className={`hero-card${work.mode === 'flexible' ? ' flexible-work' : ''}`}>
+    <div className={`hero-card${work.dayType === 'work' && work.mode === 'flexible' ? ' flexible-work' : ''}`}>
       <div className="hero-glow" />
-      <div className="hero-heading-row"><p className="hero-label"><Sparkles size={16}/> {work.mode === 'flexible' ? '今日实际已赚' : '今日已经赚了'}</p><span className="hero-mode-status">{work.mode === 'flexible' ? statusLabels[work.status] : '固定作息 · 自动计薪'}</span></div>
+      <div className="hero-heading-row"><p className="hero-label"><Sparkles size={16}/> {heroLabel}</p><span className="hero-mode-status">{modeStatus}</span></div>
       <div className="money-ticker">{money(earned)}</div>
-      <p className="rate-line">+ ¥{rates.second.toFixed(5)} / 秒</p>
+      <p className="rate-line">{work.dayType === 'rest' ? '休息日不自动计薪' : work.dayType === 'leave' ? '已按照薪苦日历中的出勤设置计算' : `+ ¥${rates.second.toFixed(5)} / 秒`}</p>
 
-      {work.mode === 'flexible' && <div className="work-controls">
+      {work.dayType === 'work' && work.mode === 'flexible' && <div className="work-controls">
         {work.status === 'ready' && <><button type="button" className="hero-work-primary" onClick={()=>setDialogPurpose('start')}><Play size={16}/>开始工作</button><button type="button" className="hero-work-link" onClick={useScheduledToday}>今天按固定作息</button></>}
         {work.status === 'working' && <><button type="button" className="hero-work-primary" onClick={pauseWork}><Pause size={16}/>暂停</button><button type="button" className="hero-work-secondary" onClick={endWork}><Square size={15}/>结束工作</button><button type="button" className="hero-work-link" onClick={()=>setDialogPurpose('adjust')}>修正时间</button></>}
         {work.status === 'paused' && <><button type="button" className="hero-work-primary" onClick={resumeWork}><Play size={16}/>继续工作</button><button type="button" className="hero-work-secondary" onClick={endWork}><Square size={15}/>结束今天</button><button type="button" className="hero-work-link" onClick={()=>setDialogPurpose('adjust')}>修正时间</button></>}
         {work.status === 'ended' && <><span className="work-ended-label">今天辛苦了</span><button type="button" className="hero-work-link" onClick={()=>setDialogPurpose('adjust')}><RotateCcw size={13}/>修正时间</button></>}
       </div>}
 
-      <div className={`progress-row${work.mode === 'flexible' ? ' flexible' : ''}`}><span>{work.mode === 'flexible' ? firstStart ? toLocalTimeValue(new Date(firstStart)) : '未开始' : profile.workStartTime}</span><div className="progress-track"><div className="progress-fill" style={{ width:`${progress}%` }}/><i style={{ left:`calc(${progress}% - 5px)` }}/></div><span>{work.mode === 'flexible' ? `目标 ${formatDuration(rates.paidSecondsPerDay)}` : profile.workEndTime}</span></div>
-      <div className="hero-meta"><span>工作进度 <b>{progress.toFixed(0)}%</b></span><span>已计薪 <b>{formatDuration(worked)}</b></span><span>{work.mode === 'flexible' ? '完成目标可赚' : '今日预计'} <b>{money(rates.daily)}</b></span>{work.mode === 'scheduled' && <button type="button" className="hero-mode-switch" onClick={()=>setDialogPurpose('start')}>今天弹性上班</button>}</div>
+      {work.dayType === 'work' ? <>
+        <div className={`progress-row${work.mode === 'flexible' ? ' flexible' : ''}`}><span>{work.mode === 'flexible' ? firstStart ? toLocalTimeValue(new Date(firstStart)) : '未开始' : profile.workStartTime}</span><div className="progress-track"><div className="progress-fill" style={{ width:`${progress}%` }}/><i style={{ left:`calc(${progress}% - 5px)` }}/></div><span>{work.mode === 'flexible' ? `目标 ${formatDuration(rates.paidSecondsPerDay)}` : profile.workEndTime}</span></div>
+        <div className="hero-meta"><span>工作进度 <b>{progress.toFixed(0)}%</b></span><span>已计薪 <b>{formatDuration(worked)}</b></span><span>{work.mode === 'flexible' ? '完成目标可赚' : '今日预计'} <b>{money(rates.daily)}</b></span>{work.mode === 'scheduled' && <button type="button" className="hero-mode-switch" onClick={()=>setDialogPurpose('start')}>今天弹性上班</button>}</div>
+      </> : <>
+        <div className="dashboard-day-note">{work.dayType === 'rest' ? '默认休息日不会计算工资；如果今天实际上班，可以手工开始计薪。' : `${leaveLabel}已覆盖今天的默认计薪安排。`}</div>
+        <div className="hero-meta"><span>今日状态 <b>{work.dayType === 'rest' ? '休息' : leaveLabel}</b></span><span>计薪方式 <b>{work.dayType === 'rest' ? '不自动计薪' : attendancePayLabel}</b></span><span>今日收入 <b>{money(earned)}</b></span>{work.dayType === 'rest' && <button type="button" className="hero-mode-switch" onClick={()=>setDialogPurpose('start')}>今天也上班</button>}</div>
+      </>}
     </div>
 
     <div className="metric-grid dashboard-metric-grid">


### PR DESCRIPTION
## What changed
- apply configured workdays before fixed-schedule homepage salary calculation
- let flexible sessions, one-day fixed-schedule overrides, and explicit normal attendance override a rest day
- apply leave pay settings before automatic homepage salary calculation
- show clear rest-day and leave states instead of a ticking salary
- keep a “今天也上班” entry on rest days

## Verification
- 19 unit tests pass, including Saturday five-day/six-day schedules, temporary work overrides, normal attendance, unpaid leave, and multiplier-paid leave
- workspace typecheck passes
- production web build and PWA verification pass