### PR TITLE
fix: 修复 Safari 无法结束摸鱼计时

### DIFF
--- a/apps/web/src/lib/id.test.ts
+++ b/apps/web/src/lib/id.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { createId } from './id'
+
+describe('createId', () => {
+  it('uses randomUUID when the browser provides it', () => {
+    const expected = '37d27829-fc20-4a88-a88f-046fef2e969f'
+    const cryptoApi = { randomUUID: () => expected, getRandomValues: <T extends ArrayBufferView>(value: T) => value }
+    expect(createId(cryptoApi as Crypto)).toBe(expected)
+  })
+
+  it('creates a UUID when Safari does not provide randomUUID', () => {
+    const cryptoApi = { getRandomValues: <T extends ArrayBufferView>(value: T) => {
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength).fill(1)
+      return value
+    } }
+    expect(createId(cryptoApi as Crypto)).toMatch(/^01010101-0101-4101-8101-010101010101$/)
+  })
+
+  it('still creates an id when the crypto API is unavailable', () => {
+    expect(createId(null)).toMatch(/^money-dance-/)
+  })
+})

--- a/apps/web/src/lib/id.ts
+++ b/apps/web/src/lib/id.ts
@@ -1,0 +1,14 @@
+type CryptoLike = Pick<Crypto, 'getRandomValues'> & Partial<Pick<Crypto, 'randomUUID'>>
+
+function bytesToUuid(bytes: Uint8Array): string {
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const value = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+  return `${value.slice(0, 8)}-${value.slice(8, 12)}-${value.slice(12, 16)}-${value.slice(16, 20)}-${value.slice(20)}`
+}
+
+export function createId(cryptoApi: CryptoLike | null | undefined = globalThis.crypto): string {
+  if (typeof cryptoApi?.randomUUID === 'function') return cryptoApi.randomUUID()
+  if (typeof cryptoApi?.getRandomValues === 'function') return bytesToUuid(cryptoApi.getRandomValues(new Uint8Array(16)))
+  return `money-dance-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}

--- a/apps/web/src/lib/storage.test.ts
+++ b/apps/web/src/lib/storage.test.ts
@@ -1,0 +1,16 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { removeJSON, saveJSON } from './storage'
+
+describe('storage writes', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('does not interrupt an action when Safari rejects a write', () => {
+    vi.stubGlobal('localStorage', { setItem: () => { throw new DOMException('blocked', 'QuotaExceededError') } })
+    expect(saveJSON('test', { value: 1 })).toBe(false)
+  })
+
+  it('does not interrupt an action when Safari rejects a removal', () => {
+    vi.stubGlobal('localStorage', { removeItem: () => { throw new DOMException('blocked', 'SecurityError') } })
+    expect(removeJSON('test')).toBe(false)
+  })
+})

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -7,8 +7,22 @@ export function loadJSON<T>(key: string, fallback: T): T {
   }
 }
 
-export function saveJSON<T>(key: string, value: T): void {
-  localStorage.setItem(key, JSON.stringify(value))
+export function saveJSON<T>(key: string, value: T): boolean {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function removeJSON(key: string): boolean {
+  try {
+    localStorage.removeItem(key)
+    return true
+  } catch {
+    return false
+  }
 }
 
 export const keys = {

--- a/apps/web/src/lib/work.ts
+++ b/apps/web/src/lib/work.ts
@@ -2,6 +2,7 @@ import { calculateRates, getWorkedPaidSeconds, type SalaryProfile, type SalaryRa
 import type { AttendanceRecord, DailyWorkRecord, DailyWorkStatus, WorkSession } from '../types'
 import { isConfiguredWorkday } from './attendance'
 import { localDateWithTime, toLocalDateValue } from './form'
+import { createId } from './id'
 import { keys, loadJSON, saveJSON } from './storage'
 
 export interface TodayWorkSummary {
@@ -94,7 +95,7 @@ export function summarizeTodayWork(profile: SalaryProfile, records: DailyWorkRec
 }
 
 export function startFlexibleWork(date: string, time: string, current?: DailyWorkRecord): DailyWorkRecord {
-  const session: WorkSession = { id: crypto.randomUUID(), startTime: localDateWithTime(date, time).toISOString() }
+  const session: WorkSession = { id: createId(), startTime: localDateWithTime(date, time).toISOString() }
   return {
     date,
     mode: 'flexible',
@@ -117,7 +118,7 @@ export function resumeFlexibleWork(record: DailyWorkRecord, now = new Date()): D
   return {
     ...record,
     status: 'working',
-    sessions: [...record.sessions, { id: crypto.randomUUID(), startTime: now.toISOString() }],
+    sessions: [...record.sessions, { id: createId(), startTime: now.toISOString() }],
     updatedAt: now.toISOString(),
   }
 }
@@ -129,7 +130,7 @@ export function replaceFlexibleWorkTime(date: string, startTime: string, endTime
     date,
     mode: 'flexible',
     status: end ? 'ended' : 'working',
-    sessions: [{ id: crypto.randomUUID(), startTime: start.toISOString(), endTime: end?.toISOString() }],
+    sessions: [{ id: createId(), startTime: start.toISOString(), endTime: end?.toISOString() }],
     updatedAt: new Date().toISOString(),
   }
 }

--- a/apps/web/src/pages/Accidents.tsx
+++ b/apps/web/src/pages/Accidents.tsx
@@ -2,6 +2,7 @@ import { ArrowDownLeft, ArrowUpRight, Plus } from 'lucide-react'
 import { FormEvent, useMemo, useState } from 'react'
 import { getPageCount, getPageItems, Pagination } from '../components/Pagination'
 import { MAX_MONEY_AMOUNT, normalizeDecimalInput, parseNumberInput, preventInvalidNumberKey, toLocalDateValue } from '../lib/form'
+import { createId } from '../lib/id'
 import { localDateAtNoon, loadLedger, saveLedger } from '../lib/ledger'
 import type { LedgerDirection, LedgerEntry } from '../types'
 import './Ledger.css'
@@ -17,7 +18,7 @@ export function Accidents(){
   const [page,setPage]=useState(1)
   const accidents=useMemo(()=>ledger.filter(entry=>entry.kind==='accident').sort((a,b)=>new Date(b.occurredAt).getTime()-new Date(a.occurredAt).getTime()),[ledger])
   const currentPage=Math.min(page,getPageCount(accidents.length)); const visibleAccidents=getPageItems(accidents,currentPage)
-  const submit=(event:FormEvent<HTMLFormElement>)=>{event.preventDefault();const n=parseNumberInput(amount);if(!event.currentTarget.reportValidity()||!source.trim()||n===null||n<=0||n>MAX_MONEY_AMOUNT||!date)return;const entry:LedgerEntry={id:crypto.randomUUID(),kind:'accident',direction,amount:n,source:source.trim(),occurredAt:localDateAtNoon(date).toISOString()};const next=[entry,...ledger];setLedger(next);saveLedger(next);setPage(1);setSource('');setAmount('')}
+  const submit=(event:FormEvent<HTMLFormElement>)=>{event.preventDefault();const n=parseNumberInput(amount);if(!event.currentTarget.reportValidity()||!source.trim()||n===null||n<=0||n>MAX_MONEY_AMOUNT||!date)return;const entry:LedgerEntry={id:createId(),kind:'accident',direction,amount:n,source:source.trim(),occurredAt:localDateAtNoon(date).toISOString()};const next=[entry,...ledger];setLedger(next);saveLedger(next);setPage(1);setSource('');setAmount('')}
 
   return <section className="page"><header className="page-header"><div><p className="eyebrow">UNEXPECTED MONEY</p><h1>意外，也要算进生活里。</h1><p>记录某天突然发生的收入或花费。它不会改变你的薪资速度，但会进入账本统计。</p></div></header>
     <form className="accident-form" onSubmit={submit}><div className="direction-switch"><button type="button" className={direction==='expense'?'active expense':''} onClick={()=>setDirection('expense')}><ArrowUpRight size={16}/>意外花费</button><button type="button" className={direction==='income'?'active income':''} onClick={()=>setDirection('income')}><ArrowDownLeft size={16}/>意外收入</button></div><label><span>发生了什么</span><input required maxLength={80} autoComplete="off" value={source} onChange={e=>setSource(e.target.value)} placeholder={direction==='expense'?'例如：手机突然碎屏':'例如：意外收到奖金'}/></label><label><span>金额</span><div className="money-input"><i>¥</i><input required type="number" inputMode="decimal" min="0.01" max={MAX_MONEY_AMOUNT} step="0.01" value={amount} onKeyDown={preventInvalidNumberKey} onChange={e=>setAmount(normalizeDecimalInput(e.target.value))} placeholder="0.00"/></div></label><label><span>发生日期</span><input required type="date" max={toLocalDateValue()} value={date} onChange={e=>setDate(e.target.value)}/></label><button className="primary-button" type="submit"><Plus size={17}/>记一笔</button></form>

--- a/apps/web/src/pages/Assets.tsx
+++ b/apps/web/src/pages/Assets.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from 'react'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { getPageCount, getPageItems, Pagination } from '../components/Pagination'
 import { formatOwnershipDuration, MAX_MONEY_AMOUNT, normalizeDecimalInput, parseNumberInput, preventInvalidNumberKey, toLocalDateValue } from '../lib/form'
+import { createId } from '../lib/id'
 import { keys, loadJSON, saveJSON } from '../lib/storage'
 import { useNow } from '../lib/useNow'
 import type { OwnedItem } from '../types'
@@ -12,7 +13,7 @@ import './Assets.css'
 export function Assets() {
   const now=useNow(60_000); const [items,setItems]=useState<OwnedItem[]>(()=>loadJSON(keys.assets,[])); const [page,setPage]=useState(1); const [name,setName]=useState(''); const [price,setPrice]=useState(''); const [date,setDate]=useState(()=>toLocalDateValue()); const [category,setCategory]=useState('数码'); const [pendingDelete,setPendingDelete]=useState<OwnedItem|null>(null)
   const currentPage=Math.min(page,getPageCount(items.length)); const visibleItems=getPageItems(items,currentPage)
-  const add=(e:FormEvent<HTMLFormElement>)=>{e.preventDefault();const p=parseNumberInput(price);const d=new Date(`${date}T00:00:00`);if(!e.currentTarget.reportValidity()||!name.trim()||p===null||p<0||p>MAX_MONEY_AMOUNT||Number.isNaN(d.getTime())||d>now)return;const next=[{id:crypto.randomUUID(),name:name.trim(),price:p,purchaseDate:d.toISOString(),category,createdAt:new Date().toISOString()},...items];setItems(next);saveJSON(keys.assets,next);setPage(1);setName('');setPrice('')}
+  const add=(e:FormEvent<HTMLFormElement>)=>{e.preventDefault();const p=parseNumberInput(price);const d=new Date(`${date}T00:00:00`);if(!e.currentTarget.reportValidity()||!name.trim()||p===null||p<0||p>MAX_MONEY_AMOUNT||Number.isNaN(d.getTime())||d>now)return;const next=[{id:createId(),name:name.trim(),price:p,purchaseDate:d.toISOString(),category,createdAt:new Date().toISOString()},...items];setItems(next);saveJSON(keys.assets,next);setPage(1);setName('');setPrice('')}
   const remove=()=>{if(!pendingDelete)return;const next=items.filter(i=>i.id!==pendingDelete.id);setItems(next);saveJSON(keys.assets,next);setPendingDelete(null)}
   return <section className="page"><header className="page-header"><div><p className="eyebrow">OWNERSHIP COST</p><h1>买得贵不贵，时间会给答案。</h1><p>持有时间越久，平均每小时成本越低。MVP 统计“持有成本”，不是实际使用时长。</p></div></header>
     <form className="input-card asset-form" onSubmit={add}><label><span>物品名称</span><input required maxLength={60} autoComplete="off" value={name} onChange={e=>setName(e.target.value)} placeholder="MacBook Pro"/></label><label><span>价格</span><div className="money-input"><i>¥</i><input required type="number" inputMode="decimal" min="0" max={MAX_MONEY_AMOUNT} step="0.01" value={price} onKeyDown={preventInvalidNumberKey} onChange={e=>setPrice(normalizeDecimalInput(e.target.value))} placeholder="14999"/></div></label><label><span>购买日期</span><input required type="date" max={toLocalDateValue()} value={date} onChange={e=>setDate(e.target.value)}/></label><label><span>分类</span><select required value={category} onChange={e=>setCategory(e.target.value)}><option>数码</option><option>家居</option><option>交通</option><option>兴趣</option><option>其他</option></select></label><button className="primary-button" type="submit"><Plus size={17}/> 添加物品</button></form>

--- a/apps/web/src/pages/Converter.tsx
+++ b/apps/web/src/pages/Converter.tsx
@@ -5,6 +5,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { getPageCount, getPageItems, Pagination } from '../components/Pagination'
 import { MAX_MONEY_AMOUNT, normalizeDecimalInput, parseNumberInput, preventInvalidNumberKey } from '../lib/form'
+import { createId } from '../lib/id'
 import { appendLedgerEntry } from '../lib/ledger'
 import { loadProfile } from '../lib/profile'
 import { keys, loadJSON, saveJSON } from '../lib/storage'
@@ -31,14 +32,14 @@ export function Converter() {
   const currentPage = Math.min(page, getPageCount(wishlistItems.length))
   const visibleItems = getPageItems(wishlistItems, currentPage)
 
-  const add = (e: FormEvent<HTMLFormElement>) => { e.preventDefault(); const n=parseNumberInput(price); if(!e.currentTarget.reportValidity() || !name.trim() || n===null || n<0 || n>MAX_MONEY_AMOUNT) return; const next=[{id:crypto.randomUUID(),name:name.trim(),price:n,createdAt:new Date().toISOString()},...items]; setItems(next); saveJSON(keys.wishes,next); setPage(1); setName(''); setPrice('') }
+  const add = (e: FormEvent<HTMLFormElement>) => { e.preventDefault(); const n=parseNumberInput(price); if(!e.currentTarget.reportValidity() || !name.trim() || n===null || n<0 || n>MAX_MONEY_AMOUNT) return; const next=[{id:createId(),name:name.trim(),price:n,createdAt:new Date().toISOString()},...items]; setItems(next); saveJSON(keys.wishes,next); setPage(1); setName(''); setPrice('') }
   const remove=(item:WishItem)=>{const next=items.filter(i=>i.id!==item.id);setItems(next);saveJSON(keys.wishes,next);setPending(null)}
   const purchase=(item:WishItem)=>{
     if(item.purchasedAt){setPending(null);return}
     const purchasedAt=new Date().toISOString()
     const next=items.map(i=>i.id===item.id?{...i,purchasedAt}:i)
     setItems(next);saveJSON(keys.wishes,next)
-    appendLedgerEntry({id:crypto.randomUUID(),kind:'purchase',direction:'expense',amount:item.price,source:`已买 · ${item.name}`,occurredAt:purchasedAt,linkedId:item.id})
+    appendLedgerEntry({id:createId(),kind:'purchase',direction:'expense',amount:item.price,source:`已买 · ${item.name}`,occurredAt:purchasedAt,linkedId:item.id})
     setPending(null);setShowPurchaseToast(true)
   }
   const confirmAction=()=>{if(!pending)return;pending.type==='delete'?remove(pending.item):purchase(pending.item)}

--- a/apps/web/src/pages/Overtime.tsx
+++ b/apps/web/src/pages/Overtime.tsx
@@ -1,14 +1,15 @@
 import { calculateRates, formatDuration } from '@salary-flow/core'
 import { BadgeDollarSign, BriefcaseBusiness, Play, Square, Trash2 } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { FinishToast } from '../components/FinishToast'
 import { OvertimeStartDialog } from '../components/OvertimeStartDialog'
 import { getPageCount, getPageItems, Pagination } from '../components/Pagination'
+import { createId } from '../lib/id'
 import { loadLedger, saveLedger } from '../lib/ledger'
 import { calculateOvertimeEarnings, overtimePayLabel } from '../lib/overtime'
 import { loadProfile } from '../lib/profile'
-import { keys, loadJSON, saveJSON } from '../lib/storage'
+import { keys, loadJSON, removeJSON, saveJSON } from '../lib/storage'
 import { useNow } from '../lib/useNow'
 import type { ActiveOvertime, OvertimeSession, OvertimeStartOption } from '../types'
 import './Overtime.css'
@@ -31,13 +32,14 @@ function formatStart(value: string): string {
 export function Overtime() {
   const [profile] = useState(() => loadProfile())
   const rates = useMemo(() => calculateRates(profile), [profile])
-  const now = useNow(250)
+  const now = useNow(1000)
   const [active, setActive] = useState<ActiveOvertime | null>(() => loadJSON<ActiveOvertime | null>(keys.activeOvertime, null))
   const [sessions, setSessions] = useState<OvertimeSession[]>(() => loadJSON<OvertimeSession[]>(keys.overtimeSessions, []))
   const [startDialogOpen, setStartDialogOpen] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<PendingDelete>(null)
   const [finishNotice, setFinishNotice] = useState<{ id: string; message: string } | null>(null)
   const [page, setPage] = useState(1)
+  const stoppingRef = useRef(false)
 
   const liveSeconds = active ? Math.max(0, (now.getTime() - new Date(active.startTime).getTime()) / 1000) : 0
   const liveMoney = active ? calculateOvertimeEarnings(active, liveSeconds, rates.second) : 0
@@ -58,27 +60,32 @@ export function Overtime() {
   }, [])
 
   const stop = useCallback(() => {
-    if (!active) return
-    const endTime = new Date().toISOString()
-    const durationSeconds = Math.max(0, (new Date(endTime).getTime() - new Date(active.startTime).getTime()) / 1000)
-    const session: OvertimeSession = {
-      ...active,
-      id: crypto.randomUUID(),
-      endTime,
-      durationSeconds,
-      earnedAmount: calculateOvertimeEarnings(active, durationSeconds, rates.second),
+    if (!active || stoppingRef.current) return
+    stoppingRef.current = true
+    try {
+      const endTime = new Date().toISOString()
+      const durationSeconds = Math.max(0, (new Date(endTime).getTime() - new Date(active.startTime).getTime()) / 1000)
+      const session: OvertimeSession = {
+        ...active,
+        id: createId(),
+        endTime,
+        durationSeconds,
+        earnedAmount: calculateOvertimeEarnings(active, durationSeconds, rates.second),
+      }
+      const next = [session, ...sessions]
+      setActive(null)
+      setSessions(next)
+      setPage(1)
+      removeJSON(keys.activeOvertime)
+      saveJSON(keys.overtimeSessions, next)
+      if (session.earnedAmount > 0) {
+        const ledger = loadLedger()
+        saveLedger([{ id: createId(), kind: 'overtime', direction: 'income', amount: session.earnedAmount, source: `加班收入 · ${overtimePayLabel(session)}`, occurredAt: endTime, linkedId: session.id }, ...ledger])
+      }
+      setFinishNotice({ id: session.id, message: `终于结束了，这次加班赚了¥${session.earnedAmount.toFixed(2)}，赶紧去犒劳一下自己吧` })
+    } finally {
+      stoppingRef.current = false
     }
-    const next = [session, ...sessions]
-    setSessions(next)
-    saveJSON(keys.overtimeSessions, next)
-    if (session.earnedAmount > 0) {
-      const ledger = loadLedger()
-      saveLedger([{ id: crypto.randomUUID(), kind: 'overtime', direction: 'income', amount: session.earnedAmount, source: `加班收入 · ${overtimePayLabel(session)}`, occurredAt: endTime, linkedId: session.id }, ...ledger])
-    }
-    setActive(null)
-    saveJSON(keys.activeOvertime, null)
-    setPage(1)
-    setFinishNotice({ id: session.id, message: `终于结束了，这次加班赚了¥${session.earnedAmount.toFixed(2)}，赶紧去犒劳一下自己吧` })
   }, [active, rates.second, sessions])
 
   const confirmDelete = useCallback(() => {

--- a/apps/web/src/pages/Slacking.css
+++ b/apps/web/src/pages/Slacking.css
@@ -1,5 +1,6 @@
 .clear-slacking-button:disabled{cursor:not-allowed;opacity:.42}
 .slacking-record>.slacking-delete-button{display:grid!important}
+.timer-card .stop-button,.timer-card .primary-button.big{touch-action:manipulation;-webkit-tap-highlight-color:transparent}
 
 @media(max-width:560px){
   .slacking-summary{display:grid;grid-template-columns:1fr 1fr;gap:14px 18px;align-items:start}

--- a/apps/web/src/pages/Slacking.tsx
+++ b/apps/web/src/pages/Slacking.tsx
@@ -1,11 +1,12 @@
 import { calculateRates, formatDuration, slackingEarned } from '@salary-flow/core'
 import { Fish, Play, Square, Trash2 } from 'lucide-react'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { ConfirmDialog } from '../components/ConfirmDialog'
 import { FinishToast } from '../components/FinishToast'
 import { getPageCount, getPageItems, Pagination } from '../components/Pagination'
+import { createId } from '../lib/id'
 import { loadProfile } from '../lib/profile'
-import { keys, loadJSON, saveJSON } from '../lib/storage'
+import { keys, loadJSON, removeJSON, saveJSON } from '../lib/storage'
 import { useNow } from '../lib/useNow'
 import type { SlackingSession } from '../types'
 import './Slacking.css'
@@ -13,21 +14,22 @@ import './Slacking.css'
 type PendingDelete = { type: 'all' } | { type: 'session'; session: SlackingSession } | null
 
 export function Slacking() {
-  const profile=loadProfile(); const rate=calculateRates(profile).second; const now=useNow(250)
+  const profile=loadProfile(); const rate=calculateRates(profile).second; const now=useNow(1000)
   const [active,setActive]=useState<string|null>(()=>loadJSON<string|null>(keys.activeSlacking,null))
   const [sessions,setSessions]=useState<SlackingSession[]>(()=>loadJSON(keys.sessions,[]))
   const [page,setPage]=useState(1)
   const [pendingDelete,setPendingDelete]=useState<PendingDelete>(null)
   const [finishNotice,setFinishNotice]=useState<{id:string;message:string}|null>(null)
+  const stoppingRef=useRef(false)
   const currentPage=Math.min(page,getPageCount(sessions.length)); const visibleSessions=getPageItems(sessions,currentPage)
   const liveSeconds=active?Math.max(0,(now.getTime()-new Date(active).getTime())/1000):0; const liveMoney=liveSeconds*rate
   const start=()=>{const s=new Date().toISOString();setActive(s);saveJSON(keys.activeSlacking,s)}
-  const stop=()=>{if(!active)return;const end=new Date().toISOString();const duration=Math.max(0,(new Date(end).getTime()-new Date(active).getTime())/1000);const session={id:crypto.randomUUID(),startTime:active,endTime:end,durationSeconds:duration,earnedAmount:slackingEarned(active,end,rate)};const next=[session,...sessions];setSessions(next);saveJSON(keys.sessions,next);setPage(1);setActive(null);saveJSON(keys.activeSlacking,null);setFinishNotice({id:session.id,message:`才赚了¥${session.earnedAmount.toFixed(2)}，这就不摸了？`})}
+  const stop=()=>{if(!active||stoppingRef.current)return;stoppingRef.current=true;try{const end=new Date().toISOString();const duration=Math.max(0,(new Date(end).getTime()-new Date(active).getTime())/1000);const session={id:createId(),startTime:active,endTime:end,durationSeconds:duration,earnedAmount:slackingEarned(active,end,rate)};const next=[session,...sessions];setActive(null);setSessions(next);setPage(1);removeJSON(keys.activeSlacking);saveJSON(keys.sessions,next);setFinishNotice({id:session.id,message:`才赚了¥${session.earnedAmount.toFixed(2)}，这就不摸了？`})}finally{stoppingRef.current=false}}
   const closeFinishNotice=useCallback(()=>setFinishNotice(null),[])
   const confirmDelete=()=>{if(!pendingDelete)return;if(pendingDelete.type==='all'){setSessions([]);saveJSON(keys.sessions,[]);setPage(1)}else{const next=sessions.filter(session=>session.id!==pendingDelete.session.id);setSessions(next);saveJSON(keys.sessions,next)}setPendingDelete(null)}
   const total=sessions.reduce((a,s)=>a+s.earnedAmount,0)
   return <section className="page"><header className="page-header"><div><p className="eyebrow">SLACKING TIMER</p><h1>摸鱼，也要有收益感。</h1><p>计时基于真实时间戳，刷新、锁屏、切换页面都不会让时间丢失。</p></div></header>
-    <div className={`timer-card ${active?'running':''}`}><div className="fish-orbit"><Fish size={34}/></div><p>{active?'正在摸鱼……':'今天准备摸一会儿？'}</p><div className="timer-number">{active?new Date(liveSeconds*1000).toISOString().slice(11,19):'00:00:00'}</div><small>老板已为这段时间支付</small><div className="timer-money">¥{liveMoney.toFixed(2)}</div>{active?<button className="stop-button" onClick={stop}><Square size={18}/>结束摸鱼</button>:<button className="primary-button big" onClick={start}><Play size={18}/>开始摸鱼</button>}<span className="timer-rate">+ ¥{rate.toFixed(5)} / 秒</span></div>
+    <div className={`timer-card ${active?'running':''}`}><div className="fish-orbit"><Fish size={34}/></div><p>{active?'正在摸鱼……':'今天准备摸一会儿？'}</p><div className="timer-number">{active?new Date(liveSeconds*1000).toISOString().slice(11,19):'00:00:00'}</div><small>老板已为这段时间支付</small><div className="timer-money">¥{liveMoney.toFixed(2)}</div>{active?<button type="button" className="stop-button" onClick={stop}><Square size={18}/>结束摸鱼</button>:<button type="button" className="primary-button big" onClick={start}><Play size={18}/>开始摸鱼</button>}<span className="timer-rate">+ ¥{rate.toFixed(5)} / 秒</span></div>
     <div className="summary-strip slacking-summary"><div><small>历史摸鱼收益</small><strong>¥{total.toFixed(2)}</strong></div><div><small>历史摸鱼时间</small><strong>{formatDuration(sessions.reduce((a,s)=>a+s.durationSeconds,0))}</strong></div><button type="button" className="text-button clear-slacking-button" disabled={sessions.length===0} onClick={()=>setPendingDelete({type:'all'})}><Trash2 size={15}/>清空历史</button></div>
     <div className="list-section"><div className="section-title"><h2>摸鱼记录</h2><span>{sessions.length} 次</span></div>{sessions.length===0?<div className="empty">还没有摸鱼记录。</div>:<><div className="item-list">{visibleSessions.map(s=><article className="list-card slacking-record" key={s.id}><div className="item-avatar fish">🐟</div><div className="item-main"><b>{new Date(s.startTime).toLocaleDateString('zh-CN')} {new Date(s.startTime).toLocaleTimeString('zh-CN',{hour:'2-digit',minute:'2-digit'})}</b><span>{formatDuration(s.durationSeconds)}</span></div><div className="item-result"><small>本次摸鱼</small><strong>¥{s.earnedAmount.toFixed(2)}</strong></div><button className="icon-button slacking-delete-button" type="button" onClick={()=>setPendingDelete({type:'session',session:s})} aria-label="删除这次摸鱼记录" title="删除"><Trash2 size={16}/></button></article>)}</div><Pagination total={sessions.length} page={currentPage} onPageChange={setPage}/></>}</div>
     <ConfirmDialog open={Boolean(pendingDelete)} title={pendingDelete?.type==='all'?'你要悄悄的删掉全部摸鱼记录吗？':'你要悄悄的删掉这次摸鱼记录吗？'} message={pendingDelete?.type==='session'?`${new Date(pendingDelete.session.startTime).toLocaleString('zh-CN')} · ¥${pendingDelete.session.earnedAmount.toFixed(2)}`:undefined} confirmLabel="对，打枪的不要" cancelLabel="不，我光明正大" onConfirm={confirmDelete} onCancel={()=>setPendingDelete(null)}/>

--- a/apps/web/src/pages/Summary.tsx
+++ b/apps/web/src/pages/Summary.tsx
@@ -5,6 +5,7 @@ import { LedgerCalendar } from '../components/LedgerCalendar'
 import { LedgerEntryDialog, type LedgerEntryDraft } from '../components/LedgerEntryDialog'
 import { getPageCount, getPageItems, Pagination } from '../components/Pagination'
 import { toLocalDateValue, toLocalMonthValue } from '../lib/form'
+import { createId } from '../lib/id'
 import { loadAttendanceRecords } from '../lib/attendance'
 import { getSummaryRange, loadLedger, saveLedger, summarizeLedger, type SummaryDimension, type SummaryEntry } from '../lib/ledger'
 import { loadProfile } from '../lib/profile'
@@ -75,9 +76,9 @@ export function Summary() {
   const saveDraft = useCallback((draft: LedgerEntryDraft) => {
     let next: LedgerEntry[]
     if (!editingEntry) {
-      next = [{ id: crypto.randomUUID(), kind: 'manual', ...draft }, ...ledger]
+      next = [{ id: createId(), kind: 'manual', ...draft }, ...ledger]
     } else if (editingEntry.generated) {
-      next = [{ id: crypto.randomUUID(), kind: 'salary_override', replacesId: editingEntry.id, ...draft }, ...ledger]
+      next = [{ id: createId(), kind: 'salary_override', replacesId: editingEntry.id, ...draft }, ...ledger]
     } else {
       next = ledger.map(entry => entry.id === editingEntry.ledgerEntryId ? { ...entry, ...draft } : entry)
     }
@@ -91,7 +92,7 @@ export function Summary() {
     let next: LedgerEntry[]
     if (pendingDelete.generated) {
       next = [{
-        id: crypto.randomUUID(),
+        id: createId(),
         kind: 'salary_override',
         direction: pendingDelete.direction,
         amount: pendingDelete.amount,


### PR DESCRIPTION
## 问题

部分 iPhone Safari 用户点击“结束摸鱼”时按钮有触摸反馈，但计时不会停止。

## 修复

- 为 Safari 缺少 `crypto.randomUUID()` 的环境增加安全 ID 生成兜底
- 本地存储写入或移除失败时不再中断结束操作
- 结束时优先清除页面上的活动计时状态，并移除活动计时存储键
- 增加重复触发保护和移动端触摸优化
- 摸鱼、加班计时界面改为每秒刷新一次，减少触摸期间的无效重渲染
- 同步修复结束加班及其他新增记录操作的同类兼容性风险

## 验证

- 24 个单元测试通过
- 全项目 TypeScript 类型检查通过
- 全项目生产构建通过
- PWA 构建校验通过