### PR TITLE
fix: 历史手工出勤始终进入账本计算

### DIFF
--- a/apps/web/src/lib/ledger.test.ts
+++ b/apps/web/src/lib/ledger.test.ts
@@ -88,6 +88,44 @@ describe('attendance salary recalculation', () => {
   })
 })
 
+describe('manual attendance before the salary history start date', () => {
+  const currentOnlyProfile = {
+    ...profile,
+    salaryHistoryMode: 'none' as const,
+    salaryEffectiveDate: '2026-08-28',
+  }
+
+  it('does not automatically generate salary before the effective date', () => {
+    const summary = summarizeLedger(currentOnlyProfile, [], start, end, now, [], [])
+    expect(summary.income).toBe(0)
+    expect(summary.entries).toHaveLength(0)
+  })
+
+  it('uses a fixed amount from an explicit historical attendance adjustment', () => {
+    const summary = summarizeLedger(currentOnlyProfile, [], start, end, now, [], attendance({ status: 'holiday', leaveType: undefined, payMode: 'fixed', fixedAmount: 66 }))
+    expect(summary.income).toBe(66)
+    expect(summary.entries[0]?.source).toBe('工资收入 · 带薪假')
+  })
+
+  it('uses a multiplier from an explicit historical attendance adjustment', () => {
+    const summary = summarizeLedger(currentOnlyProfile, [], start, end, now, [], attendance({ payMode: 'multiplier', multiplier: 0.5 }))
+    expect(summary.income).toBeCloseTo(50)
+    expect(summary.entries[0]?.source).toBe('工资收入 · 病假')
+  })
+
+  it('uses normal daily salary when the historical day is explicitly marked as normal', () => {
+    const summary = summarizeLedger(currentOnlyProfile, [], start, end, now, [], attendance({ status: 'normal', leaveType: undefined, payMode: undefined }))
+    expect(summary.income).toBe(100)
+    expect(summary.entries[0]?.source).toBe('工资收入')
+  })
+
+  it('keeps an explicit unpaid historical adjustment at zero', () => {
+    const summary = summarizeLedger(currentOnlyProfile, [], start, end, now, [], attendance({ status: 'holiday', leaveType: undefined, payMode: 'unpaid' }))
+    expect(summary.income).toBe(0)
+    expect(summary.entries).toHaveLength(0)
+  })
+})
+
 describe('alternating workweek salary entries', () => {
   const alternatingProfile = {
     ...profile,

--- a/apps/web/src/lib/ledger.ts
+++ b/apps/web/src/lib/ledger.ts
@@ -89,17 +89,20 @@ function salarySummaryEntries(profile: SalaryProfile, start: Date, end: Date, no
   today.setHours(0, 0, 0, 0)
   const effectiveDate = getSalaryEffectiveDate(profile, now)
   const entries: SummaryEntry[] = []
-  const rangeStart = start > effectiveDate ? start : effectiveDate
   const workRecordByDate = new Map(workRecords.map(record => [record.date, record]))
   const attendanceByDate = new Map(attendanceRecords.map(record => [record.date, record]))
 
-  for (const cursor = new Date(rangeStart); cursor < end; cursor.setDate(cursor.getDate() + 1)) {
+  for (const cursor = new Date(start); cursor < end; cursor.setDate(cursor.getDate() + 1)) {
     const day = new Date(cursor)
     day.setHours(0, 0, 0, 0)
     if (day > today) break
     const date = toLocalDateValue(day)
     const workRecord = workRecordByDate.get(date)
     const attendance = attendanceByDate.get(date)
+    // The effective date only limits automatically generated history. A saved
+    // attendance adjustment is an explicit instruction and must still be
+    // reflected in the ledger, even when it predates the salary history range.
+    if (day < effectiveDate && !attendance) continue
     let amount = 0
     let source = '工资收入'
     if (attendance?.status === 'leave' || attendance?.status === 'holiday') {


### PR DESCRIPTION
## 修复内容
- 薪资历史生效日只限制自动生成的历史工资
- 用户明确调整的历史出勤不再被生效日截断
- 固定金额、工资倍率、正常出勤和无薪状态均按设置进入账本
- 生效日前未调整的日期仍不会自动补算工资

## 验证
- 全量测试：55/55 通过（Web 47 + Core 8）
- TypeScript 类型检查通过
- 生产构建及 PWA 校验通过