### PR TITLE
fix: 跨日加班收入归属开始日期

### DIFF
--- a/apps/web/src/lib/overtime.test.ts
+++ b/apps/web/src/lib/overtime.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { OvertimeSession } from '../types'
+import { createOvertimeLedgerEntries, splitOvertimeSessionByLocalDay } from './overtime'
+
+function session(start: Date, end: Date): Pick<OvertimeSession, 'startTime' | 'endTime'> {
+  return {
+    startTime: start.toISOString(),
+    endTime: end.toISOString(),
+  }
+}
+
+describe('cross-day overtime attribution', () => {
+  it('splits duration at the user local midnight', () => {
+    const shares = splitOvertimeSessionByLocalDay(session(
+      new Date(2026, 7, 31, 23, 30),
+      new Date(2026, 8, 1, 1, 30),
+    ))
+
+    expect(shares.map(share => share.date)).toEqual(['2026-08-31', '2026-09-01'])
+    expect(shares.map(share => share.durationSeconds)).toEqual([1800, 5400])
+  })
+
+  it('keeps both local-day time slices for a cross-day session', () => {
+    const shares = splitOvertimeSessionByLocalDay(session(
+      new Date(2026, 7, 31, 23),
+      new Date(2026, 8, 1, 1),
+    ))
+
+    expect(shares).toHaveLength(2)
+    expect(shares.reduce((sum, share) => sum + share.durationSeconds, 0)).toBe(7200)
+  })
+
+  it('keeps a zero-duration session on the local start date', () => {
+    const start = new Date(2026, 7, 31, 23, 59)
+    const shares = splitOvertimeSessionByLocalDay(session(start, start))
+
+    expect(shares).toEqual([{
+      date: '2026-08-31',
+      startTime: start.toISOString(),
+      endTime: start.toISOString(),
+      durationSeconds: 0,
+    }])
+  })
+
+  it('records the full income once on the local start date', () => {
+    const start = new Date(2026, 7, 31, 23, 30)
+    const end = new Date(2026, 8, 1, 1, 30)
+    const entries = createOvertimeLedgerEntries({
+      id: 'overtime-1',
+      payMode: 'fixed',
+      fixedAmount: 40,
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+      durationSeconds: 7200,
+      earnedAmount: 40,
+    }, (() => {
+      let index = 0
+      return () => `ledger-${index += 1}`
+    })())
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.amount).toBe(40)
+    expect(entries[0]?.linkedId).toBe('overtime-1')
+    expect(entries[0]?.source).toBe('加班收入 · 固定 ¥40.00')
+    expect(entries[0]?.occurredAt).toBe(start.toISOString())
+  })
+})

--- a/apps/web/src/lib/overtime.ts
+++ b/apps/web/src/lib/overtime.ts
@@ -1,4 +1,4 @@
-import type { ActiveOvertime } from '../types'
+import type { ActiveOvertime, LedgerEntry, OvertimeSession } from '../types'
 
 export const OVERTIME_MULTIPLIERS = [1, 1.5, 2, 3, 4, 5] as const
 
@@ -12,4 +12,67 @@ export function overtimePayLabel(option: Pick<ActiveOvertime, 'payMode' | 'multi
   if (option.payMode === 'unpaid') return '无加班费'
   if (option.payMode === 'fixed') return `固定 ¥${(option.fixedAmount ?? 0).toFixed(2)}`
   return `${option.multiplier ?? 1} 倍工资`
+}
+
+export interface OvertimeDaySlice {
+  date: string
+  startTime: string
+  endTime: string
+  durationSeconds: number
+}
+
+function localDateValue(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function splitByLocalDay(startTime: string, endTime: string): OvertimeDaySlice[] {
+  const start = new Date(startTime)
+  const end = new Date(endTime)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime()) || end <= start) return []
+
+  const slices: OvertimeDaySlice[] = []
+  let cursor = start
+  while (cursor < end) {
+    const nextDay = new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate() + 1)
+    const sliceEnd = end < nextDay ? end : nextDay
+    slices.push({
+      date: localDateValue(cursor),
+      startTime: cursor.toISOString(),
+      endTime: sliceEnd.toISOString(),
+      durationSeconds: (sliceEnd.getTime() - cursor.getTime()) / 1000,
+    })
+    cursor = sliceEnd
+  }
+  return slices
+}
+
+export function splitOvertimeSessionByLocalDay(session: Pick<OvertimeSession, 'startTime' | 'endTime'>): OvertimeDaySlice[] {
+  const slices = splitByLocalDay(session.startTime, session.endTime)
+  if (slices.length === 0) {
+    const start = new Date(session.startTime)
+    if (Number.isNaN(start.getTime())) return []
+    return [{
+      date: localDateValue(start),
+      startTime: start.toISOString(),
+      endTime: start.toISOString(),
+      durationSeconds: 0,
+    }]
+  }
+  return slices
+}
+
+export function createOvertimeLedgerEntries(session: OvertimeSession, createEntryId: () => string): LedgerEntry[] {
+  if (session.earnedAmount <= 0) return []
+  return [{
+    id: createEntryId(),
+    kind: 'overtime',
+    direction: 'income',
+    amount: session.earnedAmount,
+    source: `加班收入 · ${overtimePayLabel(session)}`,
+    occurredAt: session.startTime,
+    linkedId: session.id,
+  }]
 }

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -6,7 +6,7 @@ import { WorkTimeDialog } from '../components/WorkTimeDialog'
 import { alternatingWeekTypeForDate, attendanceStatusLabel, loadAttendanceRecords } from '../lib/attendance'
 import { toLocalDateValue, toLocalTimeValue } from '../lib/form'
 import { loadProfile } from '../lib/profile'
-import { calculateOvertimeEarnings } from '../lib/overtime'
+import { calculateOvertimeEarnings, splitOvertimeSessionByLocalDay } from '../lib/overtime'
 import { keys, loadJSON } from '../lib/storage'
 import { useNow } from '../lib/useNow'
 import { closeActiveWorkSession, loadWorkRecords, replaceFlexibleWorkTime, resumeFlexibleWork, saveWorkRecords, scheduledOverride, startFlexibleWork, summarizeTodayWork, upsertWorkRecord } from '../lib/work'
@@ -41,11 +41,18 @@ export function Dashboard() {
   const todaySlacking = useMemo(() => slackingSessions.filter(session => toLocalDateValue(new Date(session.startTime)) === today), [slackingSessions, today])
   const slackingSeconds = useMemo(() => todaySlacking.reduce((total, session) => total + session.durationSeconds, 0), [todaySlacking])
   const slackingMoney = useMemo(() => todaySlacking.reduce((total, session) => total + session.earnedAmount, 0), [todaySlacking])
-  const todayOvertime = useMemo(() => overtimeSessions.filter(session => toLocalDateValue(new Date(session.startTime)) === today), [overtimeSessions, today])
-  const activeOvertimeToday = activeOvertime && toLocalDateValue(new Date(activeOvertime.startTime)) === today ? activeOvertime : null
-  const activeOvertimeSeconds = activeOvertimeToday ? Math.max(0, (now.getTime() - new Date(activeOvertimeToday.startTime).getTime()) / 1000) : 0
-  const overtimeSeconds = todayOvertime.reduce((total, session) => total + session.durationSeconds, 0) + activeOvertimeSeconds
-  const overtimeMoney = todayOvertime.reduce((total, session) => total + session.earnedAmount, 0) + (activeOvertimeToday ? calculateOvertimeEarnings(activeOvertimeToday, activeOvertimeSeconds, rates.second) : 0)
+  const completedOvertimeToday = useMemo(() => overtimeSessions.flatMap(splitOvertimeSessionByLocalDay).filter(slice => slice.date === today), [overtimeSessions, today])
+  const completedOvertimeMoney = useMemo(() => overtimeSessions.filter(session => toLocalDateValue(new Date(session.startTime)) === today).reduce((total, session) => total + session.earnedAmount, 0), [overtimeSessions, today])
+  const activeOvertimeSlice = useMemo(() => {
+    if (!activeOvertime) return null
+    const endTime = now.toISOString()
+    return splitOvertimeSessionByLocalDay({ startTime: activeOvertime.startTime, endTime }).find(slice => slice.date === today) ?? null
+  }, [activeOvertime, now, today])
+  const activeOvertimeMoney = activeOvertime && toLocalDateValue(new Date(activeOvertime.startTime)) === today
+    ? calculateOvertimeEarnings(activeOvertime, Math.max(0, (now.getTime() - new Date(activeOvertime.startTime).getTime()) / 1000), rates.second)
+    : 0
+  const overtimeSeconds = completedOvertimeToday.reduce((total, slice) => total + slice.durationSeconds, 0) + (activeOvertimeSlice?.durationSeconds ?? 0)
+  const overtimeMoney = completedOvertimeMoney + activeOvertimeMoney
   const wishlistItems = useMemo(() => wishes.filter(item => !item.purchasedAt), [wishes])
   const featuredWishes = wishlistItems.slice(0, 3)
   const firstStart = work.record?.sessions[0]?.startTime
@@ -123,7 +130,7 @@ export function Dashboard() {
     <div className="metric-grid dashboard-metric-grid">
       <article className="metric-card"><div className="metric-icon"><Clock3 size={18}/></div><p>你的时间单价</p><h3>{money(rates.hourly)}<small> / 小时</small></h3><span>{money(rates.minute)} / 分钟 · ¥{rates.second.toFixed(4)} / 秒</span></article>
       <article className="metric-card accent"><div className="metric-icon"><Fish size={18}/></div><p>今日摸鱼收益</p><h3>{money(slackingMoney)}</h3><span>{formatDuration(slackingSeconds)} · {earned ? (slackingMoney / earned * 100).toFixed(1) : '0.0'}% 今日收入</span><Link to="/slacking">去摸鱼计时 →</Link></article>
-      <article className="metric-card overtime-metric"><div className="metric-icon"><BriefcaseBusiness size={18}/></div><p>今日加班收入</p><h3>{money(overtimeMoney)}</h3><span>{formatDuration(overtimeSeconds)}{activeOvertimeToday ? ' · 正在加班' : ''}</span><Link to="/overtime">去加班计时 →</Link></article>
+      <article className="metric-card overtime-metric"><div className="metric-icon"><BriefcaseBusiness size={18}/></div><p>今日加班收入</p><h3>{money(overtimeMoney)}</h3><span>{formatDuration(overtimeSeconds)}{activeOvertime ? ' · 正在加班' : ''}</span><Link to="/overtime">去加班计时 →</Link></article>
     </div>
 
     <div className="section-title dashboard-wishlist-title"><div><p className="eyebrow">WISH LIST</p><h2>我的心愿清单</h2></div><Link className="dashboard-wishlist-link" to="/convert">查看全部 {wishlistItems.length} 项 <ArrowUpRight size={14}/></Link></div>

--- a/apps/web/src/pages/Overtime.tsx
+++ b/apps/web/src/pages/Overtime.tsx
@@ -7,7 +7,7 @@ import { OvertimeStartDialog } from '../components/OvertimeStartDialog'
 import { getPageCount, getPageItems, Pagination } from '../components/Pagination'
 import { createId } from '../lib/id'
 import { loadLedger, saveLedger } from '../lib/ledger'
-import { calculateOvertimeEarnings, overtimePayLabel } from '../lib/overtime'
+import { calculateOvertimeEarnings, createOvertimeLedgerEntries, overtimePayLabel } from '../lib/overtime'
 import { loadProfile } from '../lib/profile'
 import { keys, loadJSON, removeJSON, saveJSON } from '../lib/storage'
 import { useNow } from '../lib/useNow'
@@ -80,7 +80,7 @@ export function Overtime() {
       saveJSON(keys.overtimeSessions, next)
       if (session.earnedAmount > 0) {
         const ledger = loadLedger()
-        saveLedger([{ id: createId(), kind: 'overtime', direction: 'income', amount: session.earnedAmount, source: `加班收入 · ${overtimePayLabel(session)}`, occurredAt: endTime, linkedId: session.id }, ...ledger])
+        saveLedger([...createOvertimeLedgerEntries(session, createId), ...ledger])
       }
       setFinishNotice({ id: session.id, message: `终于结束了，这次加班赚了¥${session.earnedAmount.toFixed(2)}，赶紧去犒劳一下自己吧` })
     } finally {


### PR DESCRIPTION
## 修改内容
- 加班收入只生成一条账本明细，统一归属开始加班的本地日期
- 跨天加班不再拆分或重复分配收入
- 加班时长仍按用户本地自然日切分，首页“今日加班时长”不会漏算跨天部分
- 首页“今日加班收入”与账本保持相同的开始日期归属规则
- 删除某次加班时仍会通过关联 ID 清理对应账本明细

## 验证
- 新增跨日、跨月、零时长和账本归属回归测试
- 全量测试：59/59 通过（Web 51 + Core 8）
- TypeScript 类型检查通过
- 生产构建及 PWA 校验通过