### PR TITLE
fix: 迁移旧版加班账本归属日期

### DIFF
--- a/apps/web/src/lib/ledger.ts
+++ b/apps/web/src/lib/ledger.ts
@@ -1,8 +1,9 @@
 import { calculateEarnedToday, calculateRates, type SalaryProfile } from '@salary-flow/core'
-import type { AttendanceRecord, DailyWorkRecord, LedgerDirection, LedgerEntry, LedgerKind } from '../types'
+import type { AttendanceRecord, DailyWorkRecord, LedgerDirection, LedgerEntry, LedgerKind, OvertimeSession } from '../types'
 import { attendanceStatusLabel, isConfiguredWorkday, loadAttendanceRecords } from './attendance'
 import { toLocalDateTime, toLocalDateValue } from './form'
 import { keys, loadJSON, saveJSON } from './storage'
+import { migrateLegacyOvertimeLedgerDates } from './overtime'
 import { getFlexibleWorkedSeconds, loadWorkRecords } from './work'
 
 export type SummaryDimension = 'day' | 'month' | 'year'
@@ -28,7 +29,10 @@ export interface SummaryResult {
 }
 
 export function loadLedger(): LedgerEntry[] {
-  return loadJSON<LedgerEntry[]>(keys.ledger, [])
+  const entries = loadJSON<LedgerEntry[]>(keys.ledger, [])
+  const migrated = migrateLegacyOvertimeLedgerDates(entries, loadJSON<OvertimeSession[]>(keys.overtimeSessions, []))
+  if (migrated !== entries) saveLedger(migrated)
+  return migrated
 }
 
 export function saveLedger(entries: LedgerEntry[]): void {

--- a/apps/web/src/lib/overtime.test.ts
+++ b/apps/web/src/lib/overtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { OvertimeSession } from '../types'
-import { createOvertimeLedgerEntries, splitOvertimeSessionByLocalDay } from './overtime'
+import type { LedgerEntry, OvertimeSession } from '../types'
+import { createOvertimeLedgerEntries, migrateLegacyOvertimeLedgerDates, splitOvertimeSessionByLocalDay } from './overtime'
 
 function session(start: Date, end: Date): Pick<OvertimeSession, 'startTime' | 'endTime'> {
   return {
@@ -63,5 +63,59 @@ describe('cross-day overtime attribution', () => {
     expect(entries[0]?.linkedId).toBe('overtime-1')
     expect(entries[0]?.source).toBe('加班收入 · 固定 ¥40.00')
     expect(entries[0]?.occurredAt).toBe(start.toISOString())
+  })
+
+  it('migrates an untouched legacy ledger entry from end time to start time', () => {
+    const start = new Date(2026, 7, 31, 23, 30)
+    const end = new Date(2026, 8, 1, 1, 30)
+    const overtime: OvertimeSession = {
+      id: 'overtime-1',
+      payMode: 'fixed',
+      fixedAmount: 40,
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+      durationSeconds: 7200,
+      earnedAmount: 40,
+    }
+    const legacy: LedgerEntry = {
+      id: 'ledger-1',
+      kind: 'overtime',
+      direction: 'income',
+      amount: 40,
+      source: '加班收入 · 固定 ¥40.00',
+      occurredAt: end.toISOString(),
+      linkedId: overtime.id,
+    }
+
+    expect(migrateLegacyOvertimeLedgerDates([legacy], [overtime])[0]?.occurredAt).toBe(start.toISOString())
+  })
+
+  it('preserves a historical ledger entry after the user edits its date', () => {
+    const start = new Date(2026, 7, 31, 23, 30)
+    const end = new Date(2026, 8, 1, 1, 30)
+    const editedDate = new Date(2026, 7, 30, 12).toISOString()
+    const overtime: OvertimeSession = {
+      id: 'overtime-1',
+      payMode: 'fixed',
+      fixedAmount: 40,
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+      durationSeconds: 7200,
+      earnedAmount: 40,
+    }
+    const edited: LedgerEntry = {
+      id: 'ledger-1',
+      kind: 'overtime',
+      direction: 'income',
+      amount: 40,
+      source: '加班收入 · 固定 ¥40.00',
+      occurredAt: editedDate,
+      linkedId: overtime.id,
+    }
+
+    const entries = [edited]
+    const migrated = migrateLegacyOvertimeLedgerDates(entries, [overtime])
+    expect(migrated).toBe(entries)
+    expect(migrated[0]?.occurredAt).toBe(editedDate)
   })
 })

--- a/apps/web/src/lib/overtime.ts
+++ b/apps/web/src/lib/overtime.ts
@@ -76,3 +76,20 @@ export function createOvertimeLedgerEntries(session: OvertimeSession, createEntr
     linkedId: session.id,
   }]
 }
+
+export function migrateLegacyOvertimeLedgerDates(entries: LedgerEntry[], sessions: OvertimeSession[]): LedgerEntry[] {
+  const sessionsById = new Map(sessions.map(session => [session.id, session]))
+  let changed = false
+  const migrated = entries.map(entry => {
+    if (entry.kind !== 'overtime' || !entry.linkedId) return entry
+    const session = sessionsById.get(entry.linkedId)
+    if (!session) return entry
+    const isUntouchedLegacyEntry = entry.occurredAt === session.endTime
+      && entry.amount === session.earnedAmount
+      && entry.source === `加班收入 · ${overtimePayLabel(session)}`
+    if (!isUntouchedLegacyEntry || session.startTime === session.endTime) return entry
+    changed = true
+    return { ...entry, occurredAt: session.startTime }
+  })
+  return changed ? migrated : entries
+}


### PR DESCRIPTION
## 修改内容
- 自动识别旧版本按“结束时间”生成的加班账本明细
- 将未编辑的旧明细安全迁移到对应加班的开始日期
- 仅在金额、来源和结束时间均与原始加班记录完全一致时迁移
- 用户手工修改过金额、来源或日期的明细保持不变
- 已删除的账本明细不会被重新创建

## 验证
- 新增旧明细迁移与用户编辑保护测试
- 全量测试：61/61 通过（Web 53 + Core 8）
- TypeScript 类型检查通过
- 生产构建及 PWA 校验通过