### PR TITLE
docs: 准备 v0.2.26 热修发布

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 实时薪资 · 心愿清单 · 摸鱼 · 加班 · 账本 · 薪苦日历 · 物品持有成本
 
-[🌐 在线体验](https://money-dance-6gl.pages.dev/) · [📱 Android v0.2.25（Cloudflare R2）](https://money-dance-6gl.pages.dev/download/releases/money-dance-v0.2.25.apk) · [📦 版本记录](https://github.com/cshouuu/money-dance/releases) · [🛠️ GitHub Actions](https://github.com/cshouuu/money-dance/actions)
+[🌐 在线体验](https://money-dance-6gl.pages.dev/) · [📱 Android v0.2.26（Cloudflare R2）](https://money-dance-6gl.pages.dev/download/releases/money-dance-v0.2.26.apk) · [📦 版本记录](https://github.com/cshouuu/money-dance/releases) · [🛠️ GitHub Actions](https://github.com/cshouuu/money-dance/actions)
 
 ![CI](https://github.com/cshouuu/money-dance/actions/workflows/ci.yml/badge.svg)
 ![Android APK](https://github.com/cshouuu/money-dance/actions/workflows/build-android-apk.yml/badge.svg)
@@ -24,7 +24,7 @@ MoneyDance 是一个围绕「时间 × 工资 × 消费」构建的 local-first 
 
 项目不要求注册账号。薪资设置、计时记录、心愿、物品、出勤和账本数据默认保存在当前设备本地。
 
-**当前稳定版：v0.2.25**
+**当前稳定版：v0.2.26**
 
 ## 当前功能
 
@@ -95,7 +95,7 @@ MoneyDance 是一个围绕「时间 × 工资 × 消费」构建的 local-first 
 
 国内用户推荐通过 Cloudflare R2 下载当前正式版：
 
-**https://money-dance-6gl.pages.dev/download/releases/money-dance-v0.2.25.apk**
+**https://money-dance-6gl.pages.dev/download/releases/money-dance-v0.2.26.apk**
 
 也可以在 [GitHub Releases](https://github.com/cshouuu/money-dance/releases/latest) 查看版本说明和校验文件。
 
@@ -213,14 +213,14 @@ Android 使用 Git Tag 驱动正式发布，Tag 必须符合 `vMAJOR.MINOR.PATCH
 ~~~bash
 git checkout main
 git pull
-git tag -a v0.2.25 -m "MoneyDance v0.2.25"
-git push origin refs/tags/v0.2.25
+git tag -a v0.2.26 -m "MoneyDance v0.2.26"
+git push origin refs/tags/v0.2.26
 ~~~
 
 发布流水线会自动完成：
 
 ~~~text
-Tag v0.2.25
+Tag v0.2.26
    ↓
 解析 versionName / versionCode
    ↓


### PR DESCRIPTION
## 发布内容

v0.2.26 是针对 Android 加班计时付费弹窗的单点热修：

- 修复点击“给钱”后偶发跳过“还好给钱，给多少？”并直接按 1.5 倍开始的问题
- 付费加班不再预选倍率；必须明确选择工资倍率或固定金额
- 保持无薪加班、补记开始时间及现有账本规则不变

## 文档变更

- 将 README 当前稳定版、APK 下载地址和 Tag 示例更新为 v0.2.26
- 不包含其他功能调整

## 已完成验证

- 251 项测试
- 类型检查
- 生产 / PWA 构建
- Android APK 构建及签名烟测
- 依赖审计 0 漏洞
- 两轮独立静态复审无 P0 / P1